### PR TITLE
chore: add FreeBSD x86_64 CI build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -283,3 +283,21 @@ jobs:
             --cross-file cross-mips64.txt \
             --buildtype=release
           meson compile -C build-mips64el
+
+  freebsd:
+    name: Build (FreeBSD x86_64)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Build and test on FreeBSD
+        uses: cross-platform-actions/action@v1.3.0
+        with:
+          operating_system: freebsd
+          architecture: x86-64
+          version: '14.3'
+          run: |
+            sudo pkg install -y meson pkgconf ninja lmdb libarchive yyjson libsodium
+            meson setup build --buildtype=release
+            meson compile -C build
+            meson test -C build

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,17 @@
 
 All notable changes to this project will be documented in this file.
 
+## [Unreleased]
+
+### Added
+
+- FreeBSD support: the library builds, links, and passes its test suite on
+  FreeBSD with the libsodium signing backend; no source changes are required
+  because the seccomp dependency is optional and the install-script runner
+  already has a non-Linux path
+- CI job that builds and tests the library in a native FreeBSD x86_64 virtual
+  machine
+
 ## [1.9.0] - 2026-06-22
 
 ### Added


### PR DESCRIPTION
Adds a CI job that builds and tests libapg on FreeBSD 14.3 in a native VM (cross-platform-actions), installing dependencies with pkg.
Contributes to #20.