### PR TITLE
feat: add 32-bit assembly checksum backends (ARM, x86, RV32, MIPS32, PowerPC)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -85,6 +85,36 @@ jobs:
       - name: Test
         run: meson test -C build-san --print-errorlogs
 
+  arch-asm:
+    name: Assembly (32-bit arch validation)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install clang + lld
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y clang lld
+
+      - name: Assemble and PIC-link each 32-bit arch backend
+        run: |
+          set -e
+          assemble() {
+            dir="$1"; shift
+            for a in crc32 md5 sha256; do
+              clang "$@" -fPIC -c "arch/$dir/$a.S" -o "/tmp/${dir}_$a.o"
+            done
+            clang "$@" -shared -fPIC -fuse-ld=lld -Wl,-z,text -nostdlib \
+              "/tmp/${dir}_crc32.o" "/tmp/${dir}_md5.o" "/tmp/${dir}_sha256.o" \
+              -o "/tmp/${dir}.so"
+            echo "OK: $dir"
+          }
+          assemble arm     -target arm-linux-gnueabihf -march=armv7-a
+          assemble x86     -target i386-linux-gnu
+          assemble riscv32 -target riscv32-linux-gnu -march=rv32gc -mabi=ilp32
+          assemble mips    -target mipsel-linux-gnu -march=mips32r2
+          assemble powerpc -target powerpc-linux-gnu
+
   cross-aarch64:
     name: Cross-compile (aarch64)
     runs-on: ubuntu-latest
@@ -283,6 +313,58 @@ jobs:
             --cross-file cross-mips64.txt \
             --buildtype=release
           meson compile -C build-mips64el
+
+  cross-armhf:
+    name: Cross-compile (armhf)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Add armhf architecture
+        run: |
+          sudo dpkg --add-architecture armhf
+          sudo sed -i '/^deb \[/!s/^deb /deb [arch=amd64] /' /etc/apt/sources.list
+          sudo find /etc/apt/sources.list.d/ -name '*.list' \
+            -exec sed -i '/^deb \[/!s/^deb /deb [arch=amd64] /' {} +
+          sudo find /etc/apt/sources.list.d/ -name '*.sources' \
+            -exec sed -i '/^Architectures:/d; /^Types:/i Architectures: amd64' {} +
+          . /etc/os-release
+          sudo tee /etc/apt/sources.list.d/armhf-ports.list << EOF
+          deb [arch=armhf] http://ports.ubuntu.com/ubuntu-ports ${VERSION_CODENAME} main restricted universe
+          deb [arch=armhf] http://ports.ubuntu.com/ubuntu-ports ${VERSION_CODENAME}-updates main restricted universe
+          deb [arch=armhf] http://ports.ubuntu.com/ubuntu-ports ${VERSION_CODENAME}-security main restricted universe
+          EOF
+          sudo apt-get update
+
+      - name: Install dependencies
+        run: |
+          sudo apt-get install -y \
+            clang lld llvm \
+            gcc-arm-linux-gnueabihf \
+            meson ninja-build pkg-config \
+            libarchive-dev:armhf \
+            liblmdb-dev:armhf \
+            libsodium-dev:armhf \
+            libseccomp-dev:armhf
+
+      - name: Build yyjson for armhf
+        run: |
+          git clone --depth=1 https://github.com/ibireme/yyjson.git /tmp/yyjson
+          clang --target=arm-linux-gnueabihf -O2 -shared -fPIC \
+            -o /tmp/libyyjson.so /tmp/yyjson/src/yyjson.c
+          sudo cp /tmp/libyyjson.so /usr/lib/arm-linux-gnueabihf/
+          sudo cp /tmp/yyjson/src/yyjson.h /usr/include/
+          printf 'Name: yyjson\nDescription: Fast JSON library\nVersion: 0.0.0\nLibs: -L/usr/lib/arm-linux-gnueabihf -lyyjson\nCflags: -I/usr/include\n' | \
+            sudo tee /usr/lib/arm-linux-gnueabihf/pkgconfig/yyjson.pc
+
+      - name: Cross-compile
+        env:
+          PKG_CONFIG_LIBDIR: /usr/lib/arm-linux-gnueabihf/pkgconfig:/usr/share/pkgconfig
+        run: |
+          meson setup build-armhf \
+            --cross-file cross-arm.txt \
+            --buildtype=release
+          meson compile -C build-armhf
 
   freebsd:
     name: Build (FreeBSD x86_64)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,19 @@ All notable changes to this project will be documented in this file.
 
 ### Added
 
+- 32-bit assembly backends for the checksum module (CRC-32, MD5, SHA-256) on
+  ARM (AArch32/ARMv7), x86 (i386/IA-32), RISC-V (RV32), MIPS32 and PowerPC,
+  extending the existing 64-bit backends to 32-bit targets; each replaces the
+  portable C fallback with a hand-written scalar transform selected at build
+  time via `host_machine.cpu_family()`. The message-scheduling code assembles
+  words byte-wise, so the backends are endian-independent (validated on both
+  little- and big-endian MIPS and on big-endian PowerPC), and symbol
+  addressing is position-independent so they link cleanly into the shared
+  library
+- Cross-compilation files (`cross-arm.txt`, `cross-i386.txt`,
+  `cross-riscv32.txt`, `cross-mips.txt`, `cross-powerpc.txt`) and CI coverage:
+  an `arch-asm` job that assembles and PIC-links every 32-bit backend, plus a
+  full `armhf` cross-compile job
 - FreeBSD support: the library builds, links, and passes its test suite on
   FreeBSD with the libsodium signing backend; no source changes are required
   because the seccomp dependency is optional and the install-script runner

--- a/arch/arm/crc32.S
+++ b/arch/arm/crc32.S
@@ -1,0 +1,136 @@
+// SPDX-License-Identifier: GPL-3.0-only
+// SPDX-FileCopyrightText: 2026 Meigo™ Corporation (https://github.com/meigoc)
+
+    .text
+    .syntax unified
+    .arm
+
+    .globl  apg_crc32_hw_supported
+    .type   apg_crc32_hw_supported, %function
+apg_crc32_hw_supported:
+    mov     r0, #1
+    bx      lr
+    .size   apg_crc32_hw_supported, .-apg_crc32_hw_supported
+
+    .globl  apg_crc32_update_hw
+    .type   apg_crc32_update_hw, %function
+apg_crc32_update_hw:
+    push    {r4, lr}
+    movw    r3, #:lower16:(.Ltab - (0f + 8))
+    movt    r3, #:upper16:(.Ltab - (0f + 8))
+0:  add     r3, pc, r3
+.Lc4:
+    cmp     r2, #4
+    blo     .Lctail
+    ldrb    r4, [r1, #0]
+    eor     r4, r4, r0
+    and     r4, r4, #0xff
+    ldr     r4, [r3, r4, lsl #2]
+    lsr     r0, r0, #8
+    eor     r0, r0, r4
+    ldrb    r4, [r1, #1]
+    eor     r4, r4, r0
+    and     r4, r4, #0xff
+    ldr     r4, [r3, r4, lsl #2]
+    lsr     r0, r0, #8
+    eor     r0, r0, r4
+    ldrb    r4, [r1, #2]
+    eor     r4, r4, r0
+    and     r4, r4, #0xff
+    ldr     r4, [r3, r4, lsl #2]
+    lsr     r0, r0, #8
+    eor     r0, r0, r4
+    ldrb    r4, [r1, #3]
+    eor     r4, r4, r0
+    and     r4, r4, #0xff
+    ldr     r4, [r3, r4, lsl #2]
+    lsr     r0, r0, #8
+    eor     r0, r0, r4
+    add     r1, r1, #4
+    sub     r2, r2, #4
+    b       .Lc4
+.Lctail:
+    cmp     r2, #0
+    beq     .Lcdone
+    ldrb    r4, [r1], #1
+    eor     r4, r4, r0
+    and     r4, r4, #0xff
+    ldr     r4, [r3, r4, lsl #2]
+    lsr     r0, r0, #8
+    eor     r0, r0, r4
+    sub     r2, r2, #1
+    b       .Lctail
+.Lcdone:
+    pop     {r4, lr}
+    bx      lr
+    .size   apg_crc32_update_hw, .-apg_crc32_update_hw
+
+    .section .rodata
+    .align  4
+.Ltab:
+    .long 0x00000000,0x77073096,0xee0e612c,0x990951ba
+    .long 0x076dc419,0x706af48f,0xe963a535,0x9e6495a3
+    .long 0x0edb8832,0x79dcb8a4,0xe0d5e91e,0x97d2d988
+    .long 0x09b64c2b,0x7eb17cbd,0xe7b82d07,0x90bf1d91
+    .long 0x1db71064,0x6ab020f2,0xf3b97148,0x84be41de
+    .long 0x1adad47d,0x6ddde4eb,0xf4d4b551,0x83d385c7
+    .long 0x136c9856,0x646ba8c0,0xfd62f97a,0x8a65c9ec
+    .long 0x14015c4f,0x63066cd9,0xfa0f3d63,0x8d080df5
+    .long 0x3b6e20c8,0x4c69105e,0xd56041e4,0xa2677172
+    .long 0x3c03e4d1,0x4b04d447,0xd20d85fd,0xa50ab56b
+    .long 0x35b5a8fa,0x42b2986c,0xdbbbc9d6,0xacbcf940
+    .long 0x32d86ce3,0x45df5c75,0xdcd60dcf,0xabd13d59
+    .long 0x26d930ac,0x51de003a,0xc8d75180,0xbfd06116
+    .long 0x21b4f4b5,0x56b3c423,0xcfba9599,0xb8bda50f
+    .long 0x2802b89e,0x5f058808,0xc60cd9b2,0xb10be924
+    .long 0x2f6f7c87,0x58684c11,0xc1611dab,0xb6662d3d
+    .long 0x76dc4190,0x01db7106,0x98d220bc,0xefd5102a
+    .long 0x71b18589,0x06b6b51f,0x9fbfe4a5,0xe8b8d433
+    .long 0x7807c9a2,0x0f00f934,0x9609a88e,0xe10e9818
+    .long 0x7f6a0dbb,0x086d3d2d,0x91646c97,0xe6635c01
+    .long 0x6b6b51f4,0x1c6c6162,0x856530d8,0xf262004e
+    .long 0x6c0695ed,0x1b01a57b,0x8208f4c1,0xf50fc457
+    .long 0x65b0d9c6,0x12b7e950,0x8bbeb8ea,0xfcb9887c
+    .long 0x62dd1ddf,0x15da2d49,0x8cd37cf3,0xfbd44c65
+    .long 0x4db26158,0x3ab551ce,0xa3bc0074,0xd4bb30e2
+    .long 0x4adfa541,0x3dd895d7,0xa4d1c46d,0xd3d6f4fb
+    .long 0x4369e96a,0x346ed9fc,0xad678846,0xda60b8d0
+    .long 0x44042d73,0x33031de5,0xaa0a4c5f,0xdd0d7cc9
+    .long 0x5005713c,0x270241aa,0xbe0b1010,0xc90c2086
+    .long 0x5768b525,0x206f85b3,0xb966d409,0xce61e49f
+    .long 0x5edef90e,0x29d9c998,0xb0d09822,0xc7d7a8b4
+    .long 0x59b33d17,0x2eb40d81,0xb7bd5c3b,0xc0ba6cad
+    .long 0xedb88320,0x9abfb3b6,0x03b6e20c,0x74b1d29a
+    .long 0xead54739,0x9dd277af,0x04db2615,0x73dc1683
+    .long 0xe3630b12,0x94643b84,0x0d6d6a3e,0x7a6a5aa8
+    .long 0xe40ecf0b,0x9309ff9d,0x0a00ae27,0x7d079eb1
+    .long 0xf00f9344,0x8708a3d2,0x1e01f268,0x6906c2fe
+    .long 0xf762575d,0x806567cb,0x196c3671,0x6e6b06e7
+    .long 0xfed41b76,0x89d32be0,0x10da7a5a,0x67dd4acc
+    .long 0xf9b9df6f,0x8ebeeff9,0x17b7be43,0x60b08ed5
+    .long 0xd6d6a3e8,0xa1d1937e,0x38d8c2c4,0x4fdff252
+    .long 0xd1bb67f1,0xa6bc5767,0x3fb506dd,0x48b2364b
+    .long 0xd80d2bda,0xaf0a1b4c,0x36034af6,0x41047a60
+    .long 0xdf60efc3,0xa867df55,0x316e8eef,0x4669be79
+    .long 0xcb61b38c,0xbc66831a,0x256fd2a0,0x5268e236
+    .long 0xcc0c7795,0xbb0b4703,0x220216b9,0x5505262f
+    .long 0xc5ba3bbe,0xb2bd0b28,0x2bb45a92,0x5cb36a04
+    .long 0xc2d7ffa7,0xb5d0cf31,0x2cd99e8b,0x5bdeae1d
+    .long 0x9b64c2b0,0xec63f226,0x756aa39c,0x026d930a
+    .long 0x9c0906a9,0xeb0e363f,0x72076785,0x05005713
+    .long 0x95bf4a82,0xe2b87a14,0x7bb12bae,0x0cb61b38
+    .long 0x92d28e9b,0xe5d5be0d,0x7cdcefb7,0x0bdbdf21
+    .long 0x86d3d2d4,0xf1d4e242,0x68ddb3f8,0x1fda836e
+    .long 0x81be16cd,0xf6b9265b,0x6fb077e1,0x18b74777
+    .long 0x88085ae6,0xff0f6a70,0x66063bca,0x11010b5c
+    .long 0x8f659eff,0xf862ae69,0x616bffd3,0x166ccf45
+    .long 0xa00ae278,0xd70dd2ee,0x4e048354,0x3903b3c2
+    .long 0xa7672661,0xd06016f7,0x4969474d,0x3e6e77db
+    .long 0xaed16a4a,0xd9d65adc,0x40df0b66,0x37d83bf0
+    .long 0xa9bcae53,0xdebb9ec5,0x47b2cf7f,0x30b5ffe9
+    .long 0xbdbdf21c,0xcabac28a,0x53b39330,0x24b4a3a6
+    .long 0xbad03605,0xcdd70693,0x54de5729,0x23d967bf
+    .long 0xb3667a2e,0xc4614ab8,0x5d681b02,0x2a6f2b94
+    .long 0xb40bbe37,0xc30c8ea1,0x5a05df1b,0x2d02ef8d
+
+    .section .note.GNU-stack,"",%progbits

--- a/arch/arm/crc32.S
+++ b/arch/arm/crc32.S
@@ -1,5 +1,5 @@
-// SPDX-License-Identifier: GPL-3.0-only
-// SPDX-FileCopyrightText: 2026 Meigo™ Corporation (https://github.com/meigoc)
+/* SPDX-License-Identifier: GPL-3.0-only */
+/* SPDX-FileCopyrightText: 2026 Meigo™ Corporation (https://github.com/meigoc) */
 
     .text
     .syntax unified

--- a/arch/arm/md5.S
+++ b/arch/arm/md5.S
@@ -1,0 +1,150 @@
+// SPDX-License-Identifier: GPL-3.0-only
+// SPDX-FileCopyrightText: 2026 Meigo™ Corporation (https://github.com/meigoc)
+
+    .text
+    .syntax unified
+    .arm
+
+    .globl  apg_md5_hw_supported
+    .type   apg_md5_hw_supported, %function
+apg_md5_hw_supported:
+    mov     r0, #1
+    bx      lr
+    .size   apg_md5_hw_supported, .-apg_md5_hw_supported
+
+    .globl  apg_md5_transform_hw
+    .type   apg_md5_transform_hw, %function
+apg_md5_transform_hw:
+    push    {r4-r11, lr}
+    sub     sp, sp, #64
+
+    mov     r8, r0
+
+    mov     r2, #0
+.Lmld:
+    add     r3, r1, r2, lsl #2
+    ldrb    r0, [r3, #0]
+    ldrb    r12, [r3, #1]
+    orr     r0, r0, r12, lsl #8
+    ldrb    r12, [r3, #2]
+    orr     r0, r0, r12, lsl #16
+    ldrb    r12, [r3, #3]
+    orr     r0, r0, r12, lsl #24
+    str     r0, [sp, r2, lsl #2]
+    add     r2, r2, #1
+    cmp     r2, #16
+    blo     .Lmld
+
+    ldr     r4, [r8, #0]
+    ldr     r5, [r8, #4]
+    ldr     r6, [r8, #8]
+    ldr     r7, [r8, #12]
+
+    movw    r10, #:lower16:(.LT - (1f + 8))
+    movt    r10, #:upper16:(.LT - (1f + 8))
+1:  add     r10, pc, r10
+    movw    r11, #:lower16:(.LS - (2f + 8))
+    movt    r11, #:upper16:(.LS - (2f + 8))
+2:  add     r11, pc, r11
+    mov     r9, #0
+
+.Lrnd:
+    cmp     r9, #48
+    bhs     .LfI
+    cmp     r9, #32
+    bhs     .LfH
+    cmp     r9, #16
+    bhs     .LfG
+    eor     r2, r6, r7
+    and     r2, r2, r5
+    eor     r2, r2, r7
+    mov     r3, r9
+    b       .Lgot
+.LfG:
+    eor     r2, r5, r6
+    and     r2, r2, r7
+    eor     r2, r2, r6
+    add     r3, r9, r9, lsl #2
+    add     r3, r3, #1
+    and     r3, r3, #15
+    b       .Lgot
+.LfH:
+    eor     r2, r5, r6
+    eor     r2, r2, r7
+    add     r3, r9, r9, lsl #1
+    add     r3, r3, #5
+    and     r3, r3, #15
+    b       .Lgot
+.LfI:
+    mvn     r3, r7
+    orr     r3, r3, r5
+    eor     r2, r3, r6
+    lsl     r3, r9, #3
+    sub     r3, r3, r9
+    and     r3, r3, #15
+.Lgot:
+    ldr     r1, [sp, r3, lsl #2]
+    ldr     r0, [r10, r9, lsl #2]
+    add     r2, r2, r4
+    add     r2, r2, r1
+    add     r2, r2, r0
+    ldrb    r12, [r11, r9]
+    rsb     r0, r12, #32
+    lsl     r1, r2, r12
+    lsr     r0, r2, r0
+    orr     r2, r1, r0
+    add     r2, r2, r5
+
+    mov     r4, r7
+    mov     r7, r6
+    mov     r6, r5
+    mov     r5, r2
+
+    add     r9, r9, #1
+    cmp     r9, #64
+    blo     .Lrnd
+
+    ldr     r0, [r8, #0]
+    add     r0, r0, r4
+    str     r0, [r8, #0]
+    ldr     r0, [r8, #4]
+    add     r0, r0, r5
+    str     r0, [r8, #4]
+    ldr     r0, [r8, #8]
+    add     r0, r0, r6
+    str     r0, [r8, #8]
+    ldr     r0, [r8, #12]
+    add     r0, r0, r7
+    str     r0, [r8, #12]
+
+    add     sp, sp, #64
+    pop     {r4-r11, lr}
+    bx      lr
+    .size   apg_md5_transform_hw, .-apg_md5_transform_hw
+
+    .section .rodata
+    .align  4
+.LT:
+    .long 0xd76aa478,0xe8c7b756,0x242070db,0xc1bdceee
+    .long 0xf57c0faf,0x4787c62a,0xa8304613,0xfd469501
+    .long 0x698098d8,0x8b44f7af,0xffff5bb1,0x895cd7be
+    .long 0x6b901122,0xfd987193,0xa679438e,0x49b40821
+    .long 0xf61e2562,0xc040b340,0x265e5a51,0xe9b6c7aa
+    .long 0xd62f105d,0x02441453,0xd8a1e681,0xe7d3fbc8
+    .long 0x21e1cde6,0xc33707d6,0xf4d50d87,0x455a14ed
+    .long 0xa9e3e905,0xfcefa3f8,0x676f02d9,0x8d2a4c8a
+    .long 0xfffa3942,0x8771f681,0x6d9d6122,0xfde5380c
+    .long 0xa4beea44,0x4bdecfa9,0xf6bb4b60,0xbebfbc70
+    .long 0x289b7ec6,0xeaa127fa,0xd4ef3085,0x04881d05
+    .long 0xd9d4d039,0xe6db99e5,0x1fa27cf8,0xc4ac5665
+    .long 0xf4292244,0x432aff97,0xab9423a7,0xfc93a039
+    .long 0x655b59c3,0x8f0ccc92,0xffeff47d,0x85845dd1
+    .long 0x6fa87e4f,0xfe2ce6e0,0xa3014314,0x4e0811a1
+    .long 0xf7537e82,0xbd3af235,0x2ad7d2bb,0xeb86d391
+.LS:
+    .byte  7,12,17,22, 7,12,17,22, 7,12,17,22, 7,12,17,22
+    .byte  5, 9,14,20, 5, 9,14,20, 5, 9,14,20, 5, 9,14,20
+    .byte  4,11,16,23, 4,11,16,23, 4,11,16,23, 4,11,16,23
+    .byte  6,10,15,21, 6,10,15,21, 6,10,15,21, 6,10,15,21
+
+    .section .note.GNU-stack,"",%progbits

--- a/arch/arm/md5.S
+++ b/arch/arm/md5.S
@@ -1,5 +1,5 @@
-// SPDX-License-Identifier: GPL-3.0-only
-// SPDX-FileCopyrightText: 2026 Meigo™ Corporation (https://github.com/meigoc)
+/* SPDX-License-Identifier: GPL-3.0-only */
+/* SPDX-FileCopyrightText: 2026 Meigo™ Corporation (https://github.com/meigoc) */
 
     .text
     .syntax unified

--- a/arch/arm/sha256.S
+++ b/arch/arm/sha256.S
@@ -1,0 +1,166 @@
+// SPDX-License-Identifier: GPL-3.0-only
+// SPDX-FileCopyrightText: 2026 Meigo™ Corporation (https://github.com/meigoc)
+
+    .text
+    .syntax unified
+    .arm
+
+    .globl  apg_sha256_hw_supported
+    .type   apg_sha256_hw_supported, %function
+apg_sha256_hw_supported:
+    mov     r0, #1
+    bx      lr
+    .size   apg_sha256_hw_supported, .-apg_sha256_hw_supported
+
+    .globl  apg_sha256_transform_hw
+    .type   apg_sha256_transform_hw, %function
+apg_sha256_transform_hw:
+    push    {r4-r11, lr}
+    sub     sp, sp, #264
+    str     r0, [sp, #256]
+
+    mov     r2, #0
+.Lldw:
+    add     r3, r1, r2, lsl #2
+    ldrb    r0, [r3, #0]
+    ldrb    r12, [r3, #1]
+    lsl     r0, r0, #8
+    orr     r0, r0, r12
+    ldrb    r12, [r3, #2]
+    lsl     r0, r0, #8
+    orr     r0, r0, r12
+    ldrb    r12, [r3, #3]
+    lsl     r0, r0, #8
+    orr     r0, r0, r12
+    str     r0, [sp, r2, lsl #2]
+    add     r2, r2, #1
+    cmp     r2, #16
+    blo     .Lldw
+
+    mov     r2, #16
+.Lexp:
+    sub     r3, r2, #2
+    ldr     r0, [sp, r3, lsl #2]
+    ror     r1, r0, #17
+    eor     r1, r1, r0, ror #19
+    eor     r1, r1, r0, lsr #10
+    sub     r3, r2, #7
+    ldr     r0, [sp, r3, lsl #2]
+    add     r1, r1, r0
+    sub     r3, r2, #15
+    ldr     r0, [sp, r3, lsl #2]
+    ror     r12, r0, #7
+    eor     r12, r12, r0, ror #18
+    eor     r12, r12, r0, lsr #3
+    add     r1, r1, r12
+    sub     r3, r2, #16
+    ldr     r0, [sp, r3, lsl #2]
+    add     r1, r1, r0
+    str     r1, [sp, r2, lsl #2]
+    add     r2, r2, #1
+    cmp     r2, #64
+    blo     .Lexp
+
+    ldr     r0, [sp, #256]
+    ldr     r4, [r0, #0]
+    ldr     r5, [r0, #4]
+    ldr     r6, [r0, #8]
+    ldr     r7, [r0, #12]
+    ldr     r8, [r0, #16]
+    ldr     r9, [r0, #20]
+    ldr     r10, [r0, #24]
+    ldr     r11, [r0, #28]
+
+    movw    r12, #:lower16:(.LK - (3f + 8))
+    movt    r12, #:upper16:(.LK - (3f + 8))
+3:  add     r12, pc, r12
+    mov     lr, sp
+
+.Lround:
+    ldr     r0, [r12], #4
+    ldr     r1, [lr], #4
+    ror     r2, r8, #6
+    eor     r2, r2, r8, ror #11
+    eor     r2, r2, r8, ror #25
+    add     r0, r0, r1
+    add     r0, r0, r11
+    add     r0, r0, r2
+    and     r2, r8, r9
+    bic     r3, r10, r8
+    eor     r2, r2, r3
+    add     r0, r0, r2
+    ror     r2, r4, #2
+    eor     r2, r2, r4, ror #13
+    eor     r2, r2, r4, ror #22
+    and     r1, r4, r5
+    and     r3, r4, r6
+    eor     r1, r1, r3
+    and     r3, r5, r6
+    eor     r1, r1, r3
+    add     r2, r2, r1
+
+    mov     r11, r10
+    mov     r10, r9
+    mov     r9, r8
+    add     r8, r7, r0
+    mov     r7, r6
+    mov     r6, r5
+    mov     r5, r4
+    add     r4, r0, r2
+
+    add     r1, sp, #256
+    cmp     lr, r1
+    blo     .Lround
+
+    ldr     r0, [sp, #256]
+    ldr     r1, [r0, #0]
+    add     r1, r1, r4
+    str     r1, [r0, #0]
+    ldr     r1, [r0, #4]
+    add     r1, r1, r5
+    str     r1, [r0, #4]
+    ldr     r1, [r0, #8]
+    add     r1, r1, r6
+    str     r1, [r0, #8]
+    ldr     r1, [r0, #12]
+    add     r1, r1, r7
+    str     r1, [r0, #12]
+    ldr     r1, [r0, #16]
+    add     r1, r1, r8
+    str     r1, [r0, #16]
+    ldr     r1, [r0, #20]
+    add     r1, r1, r9
+    str     r1, [r0, #20]
+    ldr     r1, [r0, #24]
+    add     r1, r1, r10
+    str     r1, [r0, #24]
+    ldr     r1, [r0, #28]
+    add     r1, r1, r11
+    str     r1, [r0, #28]
+
+    add     sp, sp, #264
+    pop     {r4-r11, lr}
+    bx      lr
+    .size   apg_sha256_transform_hw, .-apg_sha256_transform_hw
+
+    .section .rodata
+    .align  4
+.LK:
+    .long 0x428a2f98,0x71374491,0xb5c0fbcf,0xe9b5dba5
+    .long 0x3956c25b,0x59f111f1,0x923f82a4,0xab1c5ed5
+    .long 0xd807aa98,0x12835b01,0x243185be,0x550c7dc3
+    .long 0x72be5d74,0x80deb1fe,0x9bdc06a7,0xc19bf174
+    .long 0xe49b69c1,0xefbe4786,0x0fc19dc6,0x240ca1cc
+    .long 0x2de92c6f,0x4a7484aa,0x5cb0a9dc,0x76f988da
+    .long 0x983e5152,0xa831c66d,0xb00327c8,0xbf597fc7
+    .long 0xc6e00bf3,0xd5a79147,0x06ca6351,0x14292967
+    .long 0x27b70a85,0x2e1b2138,0x4d2c6dfc,0x53380d13
+    .long 0x650a7354,0x766a0abb,0x81c2c92e,0x92722c85
+    .long 0xa2bfe8a1,0xa81a664b,0xc24b8b70,0xc76c51a3
+    .long 0xd192e819,0xd6990624,0xf40e3585,0x106aa070
+    .long 0x19a4c116,0x1e376c08,0x2748774c,0x34b0bcb5
+    .long 0x391c0cb3,0x4ed8aa4a,0x5b9cca4f,0x682e6ff3
+    .long 0x748f82ee,0x78a5636f,0x84c87814,0x8cc70208
+    .long 0x90befffa,0xa4506ceb,0xbef9a3f7,0xc67178f2
+
+    .section .note.GNU-stack,"",%progbits

--- a/arch/arm/sha256.S
+++ b/arch/arm/sha256.S
@@ -1,5 +1,5 @@
-// SPDX-License-Identifier: GPL-3.0-only
-// SPDX-FileCopyrightText: 2026 Meigo™ Corporation (https://github.com/meigoc)
+/* SPDX-License-Identifier: GPL-3.0-only */
+/* SPDX-FileCopyrightText: 2026 Meigo™ Corporation (https://github.com/meigoc) */
 
     .text
     .syntax unified

--- a/arch/mips/crc32.S
+++ b/arch/mips/crc32.S
@@ -1,0 +1,143 @@
+// SPDX-License-Identifier: GPL-3.0-only
+// SPDX-FileCopyrightText: 2026 Meigo™ Corporation (https://github.com/meigoc)
+
+    .set    reorder
+    .set    mips32r2
+    .text
+
+    .globl  apg_crc32_hw_supported
+    .type   apg_crc32_hw_supported, @function
+apg_crc32_hw_supported:
+    li      $v0, 1
+    jr      $ra
+    .size   apg_crc32_hw_supported, .-apg_crc32_hw_supported
+
+    .globl  apg_crc32_update_hw
+    .type   apg_crc32_update_hw, @function
+apg_crc32_update_hw:
+    la      $a3, .Ltab
+.Lloop4:
+    li      $t0, 4
+    blt     $a2, $t0, .Ltail
+    lbu     $t1, 0($a1)
+    xor     $t1, $t1, $a0
+    andi    $t1, $t1, 0xff
+    sll     $t1, $t1, 2
+    addu    $t1, $t1, $a3
+    lw      $t1, 0($t1)
+    srl     $a0, $a0, 8
+    xor     $a0, $a0, $t1
+    lbu     $t1, 1($a1)
+    xor     $t1, $t1, $a0
+    andi    $t1, $t1, 0xff
+    sll     $t1, $t1, 2
+    addu    $t1, $t1, $a3
+    lw      $t1, 0($t1)
+    srl     $a0, $a0, 8
+    xor     $a0, $a0, $t1
+    lbu     $t1, 2($a1)
+    xor     $t1, $t1, $a0
+    andi    $t1, $t1, 0xff
+    sll     $t1, $t1, 2
+    addu    $t1, $t1, $a3
+    lw      $t1, 0($t1)
+    srl     $a0, $a0, 8
+    xor     $a0, $a0, $t1
+    lbu     $t1, 3($a1)
+    xor     $t1, $t1, $a0
+    andi    $t1, $t1, 0xff
+    sll     $t1, $t1, 2
+    addu    $t1, $t1, $a3
+    lw      $t1, 0($t1)
+    srl     $a0, $a0, 8
+    xor     $a0, $a0, $t1
+    addiu   $a1, $a1, 4
+    addiu   $a2, $a2, -4
+    b       .Lloop4
+.Ltail:
+    beqz    $a2, .Ldone
+    lbu     $t1, 0($a1)
+    xor     $t1, $t1, $a0
+    andi    $t1, $t1, 0xff
+    sll     $t1, $t1, 2
+    addu    $t1, $t1, $a3
+    lw      $t1, 0($t1)
+    srl     $a0, $a0, 8
+    xor     $a0, $a0, $t1
+    addiu   $a1, $a1, 1
+    addiu   $a2, $a2, -1
+    b       .Ltail
+.Ldone:
+    move    $v0, $a0
+    jr      $ra
+    .size   apg_crc32_update_hw, .-apg_crc32_update_hw
+
+    .section .rodata
+    .align  4
+.Ltab:
+    .long 0x00000000,0x77073096,0xee0e612c,0x990951ba
+    .long 0x076dc419,0x706af48f,0xe963a535,0x9e6495a3
+    .long 0x0edb8832,0x79dcb8a4,0xe0d5e91e,0x97d2d988
+    .long 0x09b64c2b,0x7eb17cbd,0xe7b82d07,0x90bf1d91
+    .long 0x1db71064,0x6ab020f2,0xf3b97148,0x84be41de
+    .long 0x1adad47d,0x6ddde4eb,0xf4d4b551,0x83d385c7
+    .long 0x136c9856,0x646ba8c0,0xfd62f97a,0x8a65c9ec
+    .long 0x14015c4f,0x63066cd9,0xfa0f3d63,0x8d080df5
+    .long 0x3b6e20c8,0x4c69105e,0xd56041e4,0xa2677172
+    .long 0x3c03e4d1,0x4b04d447,0xd20d85fd,0xa50ab56b
+    .long 0x35b5a8fa,0x42b2986c,0xdbbbc9d6,0xacbcf940
+    .long 0x32d86ce3,0x45df5c75,0xdcd60dcf,0xabd13d59
+    .long 0x26d930ac,0x51de003a,0xc8d75180,0xbfd06116
+    .long 0x21b4f4b5,0x56b3c423,0xcfba9599,0xb8bda50f
+    .long 0x2802b89e,0x5f058808,0xc60cd9b2,0xb10be924
+    .long 0x2f6f7c87,0x58684c11,0xc1611dab,0xb6662d3d
+    .long 0x76dc4190,0x01db7106,0x98d220bc,0xefd5102a
+    .long 0x71b18589,0x06b6b51f,0x9fbfe4a5,0xe8b8d433
+    .long 0x7807c9a2,0x0f00f934,0x9609a88e,0xe10e9818
+    .long 0x7f6a0dbb,0x086d3d2d,0x91646c97,0xe6635c01
+    .long 0x6b6b51f4,0x1c6c6162,0x856530d8,0xf262004e
+    .long 0x6c0695ed,0x1b01a57b,0x8208f4c1,0xf50fc457
+    .long 0x65b0d9c6,0x12b7e950,0x8bbeb8ea,0xfcb9887c
+    .long 0x62dd1ddf,0x15da2d49,0x8cd37cf3,0xfbd44c65
+    .long 0x4db26158,0x3ab551ce,0xa3bc0074,0xd4bb30e2
+    .long 0x4adfa541,0x3dd895d7,0xa4d1c46d,0xd3d6f4fb
+    .long 0x4369e96a,0x346ed9fc,0xad678846,0xda60b8d0
+    .long 0x44042d73,0x33031de5,0xaa0a4c5f,0xdd0d7cc9
+    .long 0x5005713c,0x270241aa,0xbe0b1010,0xc90c2086
+    .long 0x5768b525,0x206f85b3,0xb966d409,0xce61e49f
+    .long 0x5edef90e,0x29d9c998,0xb0d09822,0xc7d7a8b4
+    .long 0x59b33d17,0x2eb40d81,0xb7bd5c3b,0xc0ba6cad
+    .long 0xedb88320,0x9abfb3b6,0x03b6e20c,0x74b1d29a
+    .long 0xead54739,0x9dd277af,0x04db2615,0x73dc1683
+    .long 0xe3630b12,0x94643b84,0x0d6d6a3e,0x7a6a5aa8
+    .long 0xe40ecf0b,0x9309ff9d,0x0a00ae27,0x7d079eb1
+    .long 0xf00f9344,0x8708a3d2,0x1e01f268,0x6906c2fe
+    .long 0xf762575d,0x806567cb,0x196c3671,0x6e6b06e7
+    .long 0xfed41b76,0x89d32be0,0x10da7a5a,0x67dd4acc
+    .long 0xf9b9df6f,0x8ebeeff9,0x17b7be43,0x60b08ed5
+    .long 0xd6d6a3e8,0xa1d1937e,0x38d8c2c4,0x4fdff252
+    .long 0xd1bb67f1,0xa6bc5767,0x3fb506dd,0x48b2364b
+    .long 0xd80d2bda,0xaf0a1b4c,0x36034af6,0x41047a60
+    .long 0xdf60efc3,0xa867df55,0x316e8eef,0x4669be79
+    .long 0xcb61b38c,0xbc66831a,0x256fd2a0,0x5268e236
+    .long 0xcc0c7795,0xbb0b4703,0x220216b9,0x5505262f
+    .long 0xc5ba3bbe,0xb2bd0b28,0x2bb45a92,0x5cb36a04
+    .long 0xc2d7ffa7,0xb5d0cf31,0x2cd99e8b,0x5bdeae1d
+    .long 0x9b64c2b0,0xec63f226,0x756aa39c,0x026d930a
+    .long 0x9c0906a9,0xeb0e363f,0x72076785,0x05005713
+    .long 0x95bf4a82,0xe2b87a14,0x7bb12bae,0x0cb61b38
+    .long 0x92d28e9b,0xe5d5be0d,0x7cdcefb7,0x0bdbdf21
+    .long 0x86d3d2d4,0xf1d4e242,0x68ddb3f8,0x1fda836e
+    .long 0x81be16cd,0xf6b9265b,0x6fb077e1,0x18b74777
+    .long 0x88085ae6,0xff0f6a70,0x66063bca,0x11010b5c
+    .long 0x8f659eff,0xf862ae69,0x616bffd3,0x166ccf45
+    .long 0xa00ae278,0xd70dd2ee,0x4e048354,0x3903b3c2
+    .long 0xa7672661,0xd06016f7,0x4969474d,0x3e6e77db
+    .long 0xaed16a4a,0xd9d65adc,0x40df0b66,0x37d83bf0
+    .long 0xa9bcae53,0xdebb9ec5,0x47b2cf7f,0x30b5ffe9
+    .long 0xbdbdf21c,0xcabac28a,0x53b39330,0x24b4a3a6
+    .long 0xbad03605,0xcdd70693,0x54de5729,0x23d967bf
+    .long 0xb3667a2e,0xc4614ab8,0x5d681b02,0x2a6f2b94
+    .long 0xb40bbe37,0xc30c8ea1,0x5a05df1b,0x2d02ef8d
+
+    .section .note.GNU-stack,"",@progbits

--- a/arch/mips/crc32.S
+++ b/arch/mips/crc32.S
@@ -1,5 +1,5 @@
-// SPDX-License-Identifier: GPL-3.0-only
-// SPDX-FileCopyrightText: 2026 Meigo™ Corporation (https://github.com/meigoc)
+/* SPDX-License-Identifier: GPL-3.0-only */
+/* SPDX-FileCopyrightText: 2026 Meigo™ Corporation (https://github.com/meigoc) */
 
     .set    reorder
     .set    mips32r2

--- a/arch/mips/md5.S
+++ b/arch/mips/md5.S
@@ -1,0 +1,175 @@
+// SPDX-License-Identifier: GPL-3.0-only
+// SPDX-FileCopyrightText: 2026 Meigo™ Corporation (https://github.com/meigoc)
+
+    .set    reorder
+    .set    mips32r2
+    .text
+
+    .globl  apg_md5_hw_supported
+    .type   apg_md5_hw_supported, @function
+apg_md5_hw_supported:
+    li      $v0, 1
+    jr      $ra
+    .size   apg_md5_hw_supported, .-apg_md5_hw_supported
+
+    .globl  apg_md5_transform_hw
+    .type   apg_md5_transform_hw, @function
+    .align  2
+apg_md5_transform_hw:
+    addiu   $sp, $sp, -96
+    sw      $s0, 0($sp)
+    sw      $s1, 4($sp)
+    sw      $s2, 8($sp)
+    sw      $s3, 12($sp)
+    sw      $s4, 16($sp)
+    sw      $s5, 20($sp)
+    sw      $s6, 24($sp)
+    sw      $s7, 28($sp)
+
+    move    $s4, $a0
+
+    li      $s5, 0
+.Lmld:
+    sll     $t0, $s5, 2
+    addu    $t0, $a1, $t0
+    lbu     $t1, 0($t0)
+    lbu     $t2, 1($t0)
+    sll     $t2, $t2, 8
+    or      $t1, $t1, $t2
+    lbu     $t2, 2($t0)
+    sll     $t2, $t2, 16
+    or      $t1, $t1, $t2
+    lbu     $t2, 3($t0)
+    sll     $t2, $t2, 24
+    or      $t1, $t1, $t2
+    sll     $t0, $s5, 2
+    addiu   $t3, $sp, 32
+    addu    $t0, $t3, $t0
+    sw      $t1, 0($t0)
+    addiu   $s5, $s5, 1
+    li      $t0, 16
+    blt     $s5, $t0, .Lmld
+
+    lw      $s0, 0($s4)
+    lw      $s1, 4($s4)
+    lw      $s2, 8($s4)
+    lw      $s3, 12($s4)
+
+    la      $s6, .LT
+    la      $s7, .LS
+    li      $s5, 0
+
+.Lrnd:
+    li      $t0, 48
+    bge     $s5, $t0, .LfI
+    li      $t0, 32
+    bge     $s5, $t0, .LfH
+    li      $t0, 16
+    bge     $s5, $t0, .LfG
+    xor     $t1, $s2, $s3
+    and     $t1, $t1, $s1
+    xor     $t1, $t1, $s3
+    move    $t2, $s5
+    b       .Lgot
+.LfG:
+    xor     $t1, $s1, $s2
+    and     $t1, $t1, $s3
+    xor     $t1, $t1, $s2
+    sll     $t2, $s5, 2
+    addu    $t2, $t2, $s5
+    addiu   $t2, $t2, 1
+    andi    $t2, $t2, 15
+    b       .Lgot
+.LfH:
+    xor     $t1, $s1, $s2
+    xor     $t1, $t1, $s3
+    sll     $t2, $s5, 1
+    addu    $t2, $t2, $s5
+    addiu   $t2, $t2, 5
+    andi    $t2, $t2, 15
+    b       .Lgot
+.LfI:
+    nor     $t2, $s3, $zero
+    or      $t2, $t2, $s1
+    xor     $t1, $t2, $s2
+    sll     $t2, $s5, 3
+    subu    $t2, $t2, $s5
+    andi    $t2, $t2, 15
+.Lgot:
+    sll     $t3, $t2, 2
+    addiu   $t4, $sp, 32
+    addu    $t3, $t4, $t3
+    lw      $t3, 0($t3)
+    sll     $t4, $s5, 2
+    addu    $t4, $s6, $t4
+    lw      $t4, 0($t4)
+    addu    $t1, $t1, $s0
+    addu    $t1, $t1, $t3
+    addu    $t1, $t1, $t4
+    addu    $t5, $s7, $s5
+    lbu     $t5, 0($t5)
+    li      $t6, 32
+    subu    $t6, $t6, $t5
+    rotrv   $t1, $t1, $t6
+    addu    $t1, $t1, $s1
+
+    move    $s0, $s3
+    move    $s3, $s2
+    move    $s2, $s1
+    move    $s1, $t1
+
+    addiu   $s5, $s5, 1
+    li      $t0, 64
+    blt     $s5, $t0, .Lrnd
+
+    lw      $t0, 0($s4)
+    addu    $s0, $s0, $t0
+    sw      $s0, 0($s4)
+    lw      $t0, 4($s4)
+    addu    $s1, $s1, $t0
+    sw      $s1, 4($s4)
+    lw      $t0, 8($s4)
+    addu    $s2, $s2, $t0
+    sw      $s2, 8($s4)
+    lw      $t0, 12($s4)
+    addu    $s3, $s3, $t0
+    sw      $s3, 12($s4)
+
+    lw      $s0, 0($sp)
+    lw      $s1, 4($sp)
+    lw      $s2, 8($sp)
+    lw      $s3, 12($sp)
+    lw      $s4, 16($sp)
+    lw      $s5, 20($sp)
+    lw      $s6, 24($sp)
+    lw      $s7, 28($sp)
+    addiu   $sp, $sp, 96
+    jr      $ra
+    .size   apg_md5_transform_hw, .-apg_md5_transform_hw
+
+    .section .rodata
+    .align  4
+.LT:
+    .long 0xd76aa478,0xe8c7b756,0x242070db,0xc1bdceee
+    .long 0xf57c0faf,0x4787c62a,0xa8304613,0xfd469501
+    .long 0x698098d8,0x8b44f7af,0xffff5bb1,0x895cd7be
+    .long 0x6b901122,0xfd987193,0xa679438e,0x49b40821
+    .long 0xf61e2562,0xc040b340,0x265e5a51,0xe9b6c7aa
+    .long 0xd62f105d,0x02441453,0xd8a1e681,0xe7d3fbc8
+    .long 0x21e1cde6,0xc33707d6,0xf4d50d87,0x455a14ed
+    .long 0xa9e3e905,0xfcefa3f8,0x676f02d9,0x8d2a4c8a
+    .long 0xfffa3942,0x8771f681,0x6d9d6122,0xfde5380c
+    .long 0xa4beea44,0x4bdecfa9,0xf6bb4b60,0xbebfbc70
+    .long 0x289b7ec6,0xeaa127fa,0xd4ef3085,0x04881d05
+    .long 0xd9d4d039,0xe6db99e5,0x1fa27cf8,0xc4ac5665
+    .long 0xf4292244,0x432aff97,0xab9423a7,0xfc93a039
+    .long 0x655b59c3,0x8f0ccc92,0xffeff47d,0x85845dd1
+    .long 0x6fa87e4f,0xfe2ce6e0,0xa3014314,0x4e0811a1
+    .long 0xf7537e82,0xbd3af235,0x2ad7d2bb,0xeb86d391
+.LS:
+    .byte  7,12,17,22, 7,12,17,22, 7,12,17,22, 7,12,17,22
+    .byte  5, 9,14,20, 5, 9,14,20, 5, 9,14,20, 5, 9,14,20
+    .byte  4,11,16,23, 4,11,16,23, 4,11,16,23, 4,11,16,23
+    .byte  6,10,15,21, 6,10,15,21, 6,10,15,21, 6,10,15,21
+
+    .section .note.GNU-stack,"",@progbits

--- a/arch/mips/md5.S
+++ b/arch/mips/md5.S
@@ -1,5 +1,5 @@
-// SPDX-License-Identifier: GPL-3.0-only
-// SPDX-FileCopyrightText: 2026 Meigo™ Corporation (https://github.com/meigoc)
+/* SPDX-License-Identifier: GPL-3.0-only */
+/* SPDX-FileCopyrightText: 2026 Meigo™ Corporation (https://github.com/meigoc) */
 
     .set    reorder
     .set    mips32r2

--- a/arch/mips/sha256.S
+++ b/arch/mips/sha256.S
@@ -1,5 +1,5 @@
-// SPDX-License-Identifier: GPL-3.0-only
-// SPDX-FileCopyrightText: 2026 Meigo™ Corporation (https://github.com/meigoc)
+/* SPDX-License-Identifier: GPL-3.0-only */
+/* SPDX-FileCopyrightText: 2026 Meigo™ Corporation (https://github.com/meigoc) */
 
     .set    reorder
     .set    mips32r2

--- a/arch/mips/sha256.S
+++ b/arch/mips/sha256.S
@@ -1,0 +1,214 @@
+// SPDX-License-Identifier: GPL-3.0-only
+// SPDX-FileCopyrightText: 2026 Meigo™ Corporation (https://github.com/meigoc)
+
+    .set    reorder
+    .set    mips32r2
+    .text
+
+    .globl  apg_sha256_hw_supported
+    .type   apg_sha256_hw_supported, @function
+apg_sha256_hw_supported:
+    li      $v0, 1
+    jr      $ra
+    .size   apg_sha256_hw_supported, .-apg_sha256_hw_supported
+
+    .globl  apg_sha256_transform_hw
+    .type   apg_sha256_transform_hw, @function
+    .align  2
+apg_sha256_transform_hw:
+    addiu   $sp, $sp, -296
+    sw      $s0, 0($sp)
+    sw      $s1, 4($sp)
+    sw      $s2, 8($sp)
+    sw      $s3, 12($sp)
+    sw      $s4, 16($sp)
+    sw      $s5, 20($sp)
+    sw      $s6, 24($sp)
+    sw      $s7, 28($sp)
+    sw      $fp, 32($sp)
+    sw      $a0, 36($sp)
+
+    li      $t7, 0
+.Lldw:
+    sll     $t0, $t7, 2
+    addu    $t0, $a1, $t0
+    lbu     $t1, 0($t0)
+    lbu     $t2, 1($t0)
+    sll     $t1, $t1, 8
+    or      $t1, $t1, $t2
+    lbu     $t2, 2($t0)
+    sll     $t1, $t1, 8
+    or      $t1, $t1, $t2
+    lbu     $t2, 3($t0)
+    sll     $t1, $t1, 8
+    or      $t1, $t1, $t2
+    sll     $t0, $t7, 2
+    addiu   $t3, $sp, 40
+    addu    $t0, $t3, $t0
+    sw      $t1, 0($t0)
+    addiu   $t7, $t7, 1
+    li      $t0, 16
+    blt     $t7, $t0, .Lldw
+
+    li      $t7, 16
+.Lexp:
+    addiu   $t0, $t7, -2
+    sll     $t0, $t0, 2
+    addiu   $t1, $sp, 40
+    addu    $t0, $t1, $t0
+    lw      $t2, 0($t0)
+    rotr    $t3, $t2, 17
+    rotr    $t4, $t2, 19
+    xor     $t3, $t3, $t4
+    srl     $t4, $t2, 10
+    xor     $t3, $t3, $t4
+    addiu   $t0, $t7, -7
+    sll     $t0, $t0, 2
+    addiu   $t1, $sp, 40
+    addu    $t0, $t1, $t0
+    lw      $t4, 0($t0)
+    addu    $t3, $t3, $t4
+    addiu   $t0, $t7, -15
+    sll     $t0, $t0, 2
+    addiu   $t1, $sp, 40
+    addu    $t0, $t1, $t0
+    lw      $t2, 0($t0)
+    rotr    $t4, $t2, 7
+    rotr    $t5, $t2, 18
+    xor     $t4, $t4, $t5
+    srl     $t5, $t2, 3
+    xor     $t4, $t4, $t5
+    addu    $t3, $t3, $t4
+    addiu   $t0, $t7, -16
+    sll     $t0, $t0, 2
+    addiu   $t1, $sp, 40
+    addu    $t0, $t1, $t0
+    lw      $t4, 0($t0)
+    addu    $t3, $t3, $t4
+    sll     $t0, $t7, 2
+    addiu   $t1, $sp, 40
+    addu    $t0, $t1, $t0
+    sw      $t3, 0($t0)
+    addiu   $t7, $t7, 1
+    li      $t0, 64
+    blt     $t7, $t0, .Lexp
+
+    lw      $t8, 36($sp)
+    lw      $s0, 0($t8)
+    lw      $s1, 4($t8)
+    lw      $s2, 8($t8)
+    lw      $s3, 12($t8)
+    lw      $s4, 16($t8)
+    lw      $s5, 20($t8)
+    lw      $s6, 24($t8)
+    lw      $s7, 28($t8)
+
+    li      $fp, 0
+
+.Lround:
+    la      $t0, .LK
+    sll     $t1, $fp, 2
+    addu    $t0, $t0, $t1
+    lw      $t0, 0($t0)
+    addiu   $t1, $sp, 40
+    sll     $t2, $fp, 2
+    addu    $t1, $t1, $t2
+    lw      $t1, 0($t1)
+    rotr    $t2, $s4, 6
+    rotr    $t3, $s4, 11
+    xor     $t2, $t2, $t3
+    rotr    $t3, $s4, 25
+    xor     $t2, $t2, $t3
+    and     $t3, $s4, $s5
+    nor     $t4, $s4, $zero
+    and     $t4, $t4, $s6
+    xor     $t3, $t3, $t4
+    addu    $t2, $t2, $t3
+    addu    $t2, $t2, $s7
+    addu    $t2, $t2, $t0
+    addu    $t2, $t2, $t1
+    rotr    $t3, $s0, 2
+    rotr    $t4, $s0, 13
+    xor     $t3, $t3, $t4
+    rotr    $t4, $s0, 22
+    xor     $t3, $t3, $t4
+    and     $t4, $s0, $s1
+    and     $t5, $s0, $s2
+    xor     $t4, $t4, $t5
+    and     $t5, $s1, $s2
+    xor     $t4, $t4, $t5
+    addu    $t3, $t3, $t4
+
+    move    $s7, $s6
+    move    $s6, $s5
+    move    $s5, $s4
+    addu    $s4, $s3, $t2
+    move    $s3, $s2
+    move    $s2, $s1
+    move    $s1, $s0
+    addu    $s0, $t2, $t3
+
+    addiu   $fp, $fp, 1
+    li      $t0, 64
+    blt     $fp, $t0, .Lround
+
+    lw      $t8, 36($sp)
+    lw      $t0, 0($t8)
+    addu    $s0, $s0, $t0
+    sw      $s0, 0($t8)
+    lw      $t0, 4($t8)
+    addu    $s1, $s1, $t0
+    sw      $s1, 4($t8)
+    lw      $t0, 8($t8)
+    addu    $s2, $s2, $t0
+    sw      $s2, 8($t8)
+    lw      $t0, 12($t8)
+    addu    $s3, $s3, $t0
+    sw      $s3, 12($t8)
+    lw      $t0, 16($t8)
+    addu    $s4, $s4, $t0
+    sw      $s4, 16($t8)
+    lw      $t0, 20($t8)
+    addu    $s5, $s5, $t0
+    sw      $s5, 20($t8)
+    lw      $t0, 24($t8)
+    addu    $s6, $s6, $t0
+    sw      $s6, 24($t8)
+    lw      $t0, 28($t8)
+    addu    $s7, $s7, $t0
+    sw      $s7, 28($t8)
+
+    lw      $s0, 0($sp)
+    lw      $s1, 4($sp)
+    lw      $s2, 8($sp)
+    lw      $s3, 12($sp)
+    lw      $s4, 16($sp)
+    lw      $s5, 20($sp)
+    lw      $s6, 24($sp)
+    lw      $s7, 28($sp)
+    lw      $fp, 32($sp)
+    addiu   $sp, $sp, 296
+    jr      $ra
+    .size   apg_sha256_transform_hw, .-apg_sha256_transform_hw
+
+    .section .rodata
+    .align  4
+.LK:
+    .long 0x428a2f98,0x71374491,0xb5c0fbcf,0xe9b5dba5
+    .long 0x3956c25b,0x59f111f1,0x923f82a4,0xab1c5ed5
+    .long 0xd807aa98,0x12835b01,0x243185be,0x550c7dc3
+    .long 0x72be5d74,0x80deb1fe,0x9bdc06a7,0xc19bf174
+    .long 0xe49b69c1,0xefbe4786,0x0fc19dc6,0x240ca1cc
+    .long 0x2de92c6f,0x4a7484aa,0x5cb0a9dc,0x76f988da
+    .long 0x983e5152,0xa831c66d,0xb00327c8,0xbf597fc7
+    .long 0xc6e00bf3,0xd5a79147,0x06ca6351,0x14292967
+    .long 0x27b70a85,0x2e1b2138,0x4d2c6dfc,0x53380d13
+    .long 0x650a7354,0x766a0abb,0x81c2c92e,0x92722c85
+    .long 0xa2bfe8a1,0xa81a664b,0xc24b8b70,0xc76c51a3
+    .long 0xd192e819,0xd6990624,0xf40e3585,0x106aa070
+    .long 0x19a4c116,0x1e376c08,0x2748774c,0x34b0bcb5
+    .long 0x391c0cb3,0x4ed8aa4a,0x5b9cca4f,0x682e6ff3
+    .long 0x748f82ee,0x78a5636f,0x84c87814,0x8cc70208
+    .long 0x90befffa,0xa4506ceb,0xbef9a3f7,0xc67178f2
+
+    .section .note.GNU-stack,"",@progbits

--- a/arch/powerpc/crc32.S
+++ b/arch/powerpc/crc32.S
@@ -1,0 +1,146 @@
+// SPDX-License-Identifier: GPL-3.0-only
+// SPDX-FileCopyrightText: 2026 Meigo™ Corporation (https://github.com/meigoc)
+
+    .text
+
+    .globl  apg_crc32_hw_supported
+    .type   apg_crc32_hw_supported, @function
+apg_crc32_hw_supported:
+    li      3, 1
+    blr
+    .size   apg_crc32_hw_supported, .-apg_crc32_hw_supported
+
+    .globl  apg_crc32_update_hw
+    .type   apg_crc32_update_hw, @function
+apg_crc32_update_hw:
+    mflr    8
+    bcl     20, 31, 0f
+0:  mflr    6
+    addis   6, 6, (.Ltab - 0b)@ha
+    addi    6, 6, (.Ltab - 0b)@l
+.Lc4:
+    cmpwi   5, 4
+    blt     .Lctail
+    lbz     7, 0(4)
+    xor     7, 7, 3
+    andi.   7, 7, 0xff
+    slwi    7, 7, 2
+    add     7, 7, 6
+    lwz     7, 0(7)
+    srwi    3, 3, 8
+    xor     3, 3, 7
+    lbz     7, 1(4)
+    xor     7, 7, 3
+    andi.   7, 7, 0xff
+    slwi    7, 7, 2
+    add     7, 7, 6
+    lwz     7, 0(7)
+    srwi    3, 3, 8
+    xor     3, 3, 7
+    lbz     7, 2(4)
+    xor     7, 7, 3
+    andi.   7, 7, 0xff
+    slwi    7, 7, 2
+    add     7, 7, 6
+    lwz     7, 0(7)
+    srwi    3, 3, 8
+    xor     3, 3, 7
+    lbz     7, 3(4)
+    xor     7, 7, 3
+    andi.   7, 7, 0xff
+    slwi    7, 7, 2
+    add     7, 7, 6
+    lwz     7, 0(7)
+    srwi    3, 3, 8
+    xor     3, 3, 7
+    addi    4, 4, 4
+    addi    5, 5, -4
+    b       .Lc4
+.Lctail:
+    cmpwi   5, 0
+    beq     .Lcdone
+    lbz     7, 0(4)
+    xor     7, 7, 3
+    andi.   7, 7, 0xff
+    slwi    7, 7, 2
+    add     7, 7, 6
+    lwz     7, 0(7)
+    srwi    3, 3, 8
+    xor     3, 3, 7
+    addi    4, 4, 1
+    addi    5, 5, -1
+    b       .Lctail
+.Lcdone:
+    mtlr    8
+    blr
+    .size   apg_crc32_update_hw, .-apg_crc32_update_hw
+
+    .section .rodata
+    .align  4
+.Ltab:
+    .long 0x00000000,0x77073096,0xee0e612c,0x990951ba
+    .long 0x076dc419,0x706af48f,0xe963a535,0x9e6495a3
+    .long 0x0edb8832,0x79dcb8a4,0xe0d5e91e,0x97d2d988
+    .long 0x09b64c2b,0x7eb17cbd,0xe7b82d07,0x90bf1d91
+    .long 0x1db71064,0x6ab020f2,0xf3b97148,0x84be41de
+    .long 0x1adad47d,0x6ddde4eb,0xf4d4b551,0x83d385c7
+    .long 0x136c9856,0x646ba8c0,0xfd62f97a,0x8a65c9ec
+    .long 0x14015c4f,0x63066cd9,0xfa0f3d63,0x8d080df5
+    .long 0x3b6e20c8,0x4c69105e,0xd56041e4,0xa2677172
+    .long 0x3c03e4d1,0x4b04d447,0xd20d85fd,0xa50ab56b
+    .long 0x35b5a8fa,0x42b2986c,0xdbbbc9d6,0xacbcf940
+    .long 0x32d86ce3,0x45df5c75,0xdcd60dcf,0xabd13d59
+    .long 0x26d930ac,0x51de003a,0xc8d75180,0xbfd06116
+    .long 0x21b4f4b5,0x56b3c423,0xcfba9599,0xb8bda50f
+    .long 0x2802b89e,0x5f058808,0xc60cd9b2,0xb10be924
+    .long 0x2f6f7c87,0x58684c11,0xc1611dab,0xb6662d3d
+    .long 0x76dc4190,0x01db7106,0x98d220bc,0xefd5102a
+    .long 0x71b18589,0x06b6b51f,0x9fbfe4a5,0xe8b8d433
+    .long 0x7807c9a2,0x0f00f934,0x9609a88e,0xe10e9818
+    .long 0x7f6a0dbb,0x086d3d2d,0x91646c97,0xe6635c01
+    .long 0x6b6b51f4,0x1c6c6162,0x856530d8,0xf262004e
+    .long 0x6c0695ed,0x1b01a57b,0x8208f4c1,0xf50fc457
+    .long 0x65b0d9c6,0x12b7e950,0x8bbeb8ea,0xfcb9887c
+    .long 0x62dd1ddf,0x15da2d49,0x8cd37cf3,0xfbd44c65
+    .long 0x4db26158,0x3ab551ce,0xa3bc0074,0xd4bb30e2
+    .long 0x4adfa541,0x3dd895d7,0xa4d1c46d,0xd3d6f4fb
+    .long 0x4369e96a,0x346ed9fc,0xad678846,0xda60b8d0
+    .long 0x44042d73,0x33031de5,0xaa0a4c5f,0xdd0d7cc9
+    .long 0x5005713c,0x270241aa,0xbe0b1010,0xc90c2086
+    .long 0x5768b525,0x206f85b3,0xb966d409,0xce61e49f
+    .long 0x5edef90e,0x29d9c998,0xb0d09822,0xc7d7a8b4
+    .long 0x59b33d17,0x2eb40d81,0xb7bd5c3b,0xc0ba6cad
+    .long 0xedb88320,0x9abfb3b6,0x03b6e20c,0x74b1d29a
+    .long 0xead54739,0x9dd277af,0x04db2615,0x73dc1683
+    .long 0xe3630b12,0x94643b84,0x0d6d6a3e,0x7a6a5aa8
+    .long 0xe40ecf0b,0x9309ff9d,0x0a00ae27,0x7d079eb1
+    .long 0xf00f9344,0x8708a3d2,0x1e01f268,0x6906c2fe
+    .long 0xf762575d,0x806567cb,0x196c3671,0x6e6b06e7
+    .long 0xfed41b76,0x89d32be0,0x10da7a5a,0x67dd4acc
+    .long 0xf9b9df6f,0x8ebeeff9,0x17b7be43,0x60b08ed5
+    .long 0xd6d6a3e8,0xa1d1937e,0x38d8c2c4,0x4fdff252
+    .long 0xd1bb67f1,0xa6bc5767,0x3fb506dd,0x48b2364b
+    .long 0xd80d2bda,0xaf0a1b4c,0x36034af6,0x41047a60
+    .long 0xdf60efc3,0xa867df55,0x316e8eef,0x4669be79
+    .long 0xcb61b38c,0xbc66831a,0x256fd2a0,0x5268e236
+    .long 0xcc0c7795,0xbb0b4703,0x220216b9,0x5505262f
+    .long 0xc5ba3bbe,0xb2bd0b28,0x2bb45a92,0x5cb36a04
+    .long 0xc2d7ffa7,0xb5d0cf31,0x2cd99e8b,0x5bdeae1d
+    .long 0x9b64c2b0,0xec63f226,0x756aa39c,0x026d930a
+    .long 0x9c0906a9,0xeb0e363f,0x72076785,0x05005713
+    .long 0x95bf4a82,0xe2b87a14,0x7bb12bae,0x0cb61b38
+    .long 0x92d28e9b,0xe5d5be0d,0x7cdcefb7,0x0bdbdf21
+    .long 0x86d3d2d4,0xf1d4e242,0x68ddb3f8,0x1fda836e
+    .long 0x81be16cd,0xf6b9265b,0x6fb077e1,0x18b74777
+    .long 0x88085ae6,0xff0f6a70,0x66063bca,0x11010b5c
+    .long 0x8f659eff,0xf862ae69,0x616bffd3,0x166ccf45
+    .long 0xa00ae278,0xd70dd2ee,0x4e048354,0x3903b3c2
+    .long 0xa7672661,0xd06016f7,0x4969474d,0x3e6e77db
+    .long 0xaed16a4a,0xd9d65adc,0x40df0b66,0x37d83bf0
+    .long 0xa9bcae53,0xdebb9ec5,0x47b2cf7f,0x30b5ffe9
+    .long 0xbdbdf21c,0xcabac28a,0x53b39330,0x24b4a3a6
+    .long 0xbad03605,0xcdd70693,0x54de5729,0x23d967bf
+    .long 0xb3667a2e,0xc4614ab8,0x5d681b02,0x2a6f2b94
+    .long 0xb40bbe37,0xc30c8ea1,0x5a05df1b,0x2d02ef8d
+
+    .section .note.GNU-stack,"",@progbits

--- a/arch/powerpc/crc32.S
+++ b/arch/powerpc/crc32.S
@@ -1,5 +1,5 @@
-// SPDX-License-Identifier: GPL-3.0-only
-// SPDX-FileCopyrightText: 2026 Meigo™ Corporation (https://github.com/meigoc)
+/* SPDX-License-Identifier: GPL-3.0-only */
+/* SPDX-FileCopyrightText: 2026 Meigo™ Corporation (https://github.com/meigoc) */
 
     .text
 

--- a/arch/powerpc/md5.S
+++ b/arch/powerpc/md5.S
@@ -1,0 +1,178 @@
+// SPDX-License-Identifier: GPL-3.0-only
+// SPDX-FileCopyrightText: 2026 Meigo™ Corporation (https://github.com/meigoc)
+
+    .text
+
+    .globl  apg_md5_hw_supported
+    .type   apg_md5_hw_supported, @function
+apg_md5_hw_supported:
+    li      3, 1
+    blr
+    .size   apg_md5_hw_supported, .-apg_md5_hw_supported
+
+    .globl  apg_md5_transform_hw
+    .type   apg_md5_transform_hw, @function
+apg_md5_transform_hw:
+    mflr    0
+    stwu    1, -112(1)
+    stw     0, 116(1)
+    stw     14, 8(1)
+    stw     15, 12(1)
+    stw     16, 16(1)
+    stw     17, 20(1)
+    stw     18, 24(1)
+    stw     19, 28(1)
+    stw     20, 32(1)
+    stw     21, 36(1)
+
+    mr      18, 3
+
+    li      19, 0
+.Lmld:
+    slwi    7, 19, 2
+    add     7, 4, 7
+    lbz     8, 0(7)
+    lbz     9, 1(7)
+    slwi    9, 9, 8
+    or      8, 8, 9
+    lbz     9, 2(7)
+    slwi    9, 9, 16
+    or      8, 8, 9
+    lbz     9, 3(7)
+    slwi    9, 9, 24
+    or      8, 8, 9
+    slwi    7, 19, 2
+    addi    10, 1, 40
+    add     7, 10, 7
+    stw     8, 0(7)
+    addi    19, 19, 1
+    cmpwi   19, 16
+    blt     .Lmld
+
+    lwz     14, 0(18)
+    lwz     15, 4(18)
+    lwz     16, 8(18)
+    lwz     17, 12(18)
+
+    bcl     20, 31, 0f
+0:  mflr    7
+    addis   20, 7, (.LT - 0b)@ha
+    addi    20, 20, (.LT - 0b)@l
+    addis   21, 7, (.LS - 0b)@ha
+    addi    21, 21, (.LS - 0b)@l
+    li      19, 0
+
+.Lrnd:
+    cmpwi   19, 48
+    bge     .LfI
+    cmpwi   19, 32
+    bge     .LfH
+    cmpwi   19, 16
+    bge     .LfG
+    xor     7, 16, 17
+    and     7, 7, 15
+    xor     7, 7, 17
+    mr      8, 19
+    b       .Lgot
+.LfG:
+    xor     7, 15, 16
+    and     7, 7, 17
+    xor     7, 7, 16
+    slwi    8, 19, 2
+    add     8, 8, 19
+    addi    8, 8, 1
+    andi.   8, 8, 15
+    b       .Lgot
+.LfH:
+    xor     7, 15, 16
+    xor     7, 7, 17
+    slwi    8, 19, 1
+    add     8, 8, 19
+    addi    8, 8, 5
+    andi.   8, 8, 15
+    b       .Lgot
+.LfI:
+    not     8, 17
+    or      8, 8, 15
+    xor     7, 8, 16
+    slwi    8, 19, 3
+    sub     8, 8, 19
+    andi.   8, 8, 15
+.Lgot:
+    slwi    9, 8, 2
+    addi    10, 1, 40
+    add     9, 10, 9
+    lwz     9, 0(9)
+    slwi    10, 19, 2
+    add     10, 20, 10
+    lwz     10, 0(10)
+    add     7, 7, 14
+    add     7, 7, 9
+    add     7, 7, 10
+    add     11, 21, 19
+    lbz     11, 0(11)
+    rlwnm   7, 7, 11, 0, 31
+    add     7, 7, 15
+
+    mr      14, 17
+    mr      17, 16
+    mr      16, 15
+    mr      15, 7
+
+    addi    19, 19, 1
+    cmpwi   19, 64
+    blt     .Lrnd
+
+    lwz     7, 0(18)
+    add     14, 14, 7
+    stw     14, 0(18)
+    lwz     7, 4(18)
+    add     15, 15, 7
+    stw     15, 4(18)
+    lwz     7, 8(18)
+    add     16, 16, 7
+    stw     16, 8(18)
+    lwz     7, 12(18)
+    add     17, 17, 7
+    stw     17, 12(18)
+
+    lwz     14, 8(1)
+    lwz     15, 12(1)
+    lwz     16, 16(1)
+    lwz     17, 20(1)
+    lwz     18, 24(1)
+    lwz     19, 28(1)
+    lwz     20, 32(1)
+    lwz     21, 36(1)
+    lwz     0, 116(1)
+    mtlr    0
+    addi    1, 1, 112
+    blr
+    .size   apg_md5_transform_hw, .-apg_md5_transform_hw
+
+    .section .rodata
+    .align  4
+.LT:
+    .long 0xd76aa478,0xe8c7b756,0x242070db,0xc1bdceee
+    .long 0xf57c0faf,0x4787c62a,0xa8304613,0xfd469501
+    .long 0x698098d8,0x8b44f7af,0xffff5bb1,0x895cd7be
+    .long 0x6b901122,0xfd987193,0xa679438e,0x49b40821
+    .long 0xf61e2562,0xc040b340,0x265e5a51,0xe9b6c7aa
+    .long 0xd62f105d,0x02441453,0xd8a1e681,0xe7d3fbc8
+    .long 0x21e1cde6,0xc33707d6,0xf4d50d87,0x455a14ed
+    .long 0xa9e3e905,0xfcefa3f8,0x676f02d9,0x8d2a4c8a
+    .long 0xfffa3942,0x8771f681,0x6d9d6122,0xfde5380c
+    .long 0xa4beea44,0x4bdecfa9,0xf6bb4b60,0xbebfbc70
+    .long 0x289b7ec6,0xeaa127fa,0xd4ef3085,0x04881d05
+    .long 0xd9d4d039,0xe6db99e5,0x1fa27cf8,0xc4ac5665
+    .long 0xf4292244,0x432aff97,0xab9423a7,0xfc93a039
+    .long 0x655b59c3,0x8f0ccc92,0xffeff47d,0x85845dd1
+    .long 0x6fa87e4f,0xfe2ce6e0,0xa3014314,0x4e0811a1
+    .long 0xf7537e82,0xbd3af235,0x2ad7d2bb,0xeb86d391
+.LS:
+    .byte  7,12,17,22, 7,12,17,22, 7,12,17,22, 7,12,17,22
+    .byte  5, 9,14,20, 5, 9,14,20, 5, 9,14,20, 5, 9,14,20
+    .byte  4,11,16,23, 4,11,16,23, 4,11,16,23, 4,11,16,23
+    .byte  6,10,15,21, 6,10,15,21, 6,10,15,21, 6,10,15,21
+
+    .section .note.GNU-stack,"",@progbits

--- a/arch/powerpc/md5.S
+++ b/arch/powerpc/md5.S
@@ -1,5 +1,5 @@
-// SPDX-License-Identifier: GPL-3.0-only
-// SPDX-FileCopyrightText: 2026 Meigo™ Corporation (https://github.com/meigoc)
+/* SPDX-License-Identifier: GPL-3.0-only */
+/* SPDX-FileCopyrightText: 2026 Meigo™ Corporation (https://github.com/meigoc) */
 
     .text
 

--- a/arch/powerpc/sha256.S
+++ b/arch/powerpc/sha256.S
@@ -1,0 +1,216 @@
+// SPDX-License-Identifier: GPL-3.0-only
+// SPDX-FileCopyrightText: 2026 Meigo™ Corporation (https://github.com/meigoc)
+
+    .text
+
+    .globl  apg_sha256_hw_supported
+    .type   apg_sha256_hw_supported, @function
+apg_sha256_hw_supported:
+    li      3, 1
+    blr
+    .size   apg_sha256_hw_supported, .-apg_sha256_hw_supported
+
+    .globl  apg_sha256_transform_hw
+    .type   apg_sha256_transform_hw, @function
+apg_sha256_transform_hw:
+    mflr    0
+    stwu    1, -320(1)
+    stw     0, 324(1)
+    stw     14, 8(1)
+    stw     15, 12(1)
+    stw     16, 16(1)
+    stw     17, 20(1)
+    stw     18, 24(1)
+    stw     19, 28(1)
+    stw     20, 32(1)
+    stw     21, 36(1)
+    stw     22, 40(1)
+    stw     23, 44(1)
+    stw     24, 48(1)
+    stw     25, 52(1)
+
+    mr      22, 3
+    addi    25, 1, 56
+
+    li      3, 0
+.Lldw:
+    slwi    7, 3, 2
+    add     7, 4, 7
+    lbz     8, 0(7)
+    lbz     9, 1(7)
+    slwi    8, 8, 8
+    or      8, 8, 9
+    lbz     9, 2(7)
+    slwi    8, 8, 8
+    or      8, 8, 9
+    lbz     9, 3(7)
+    slwi    8, 8, 8
+    or      8, 8, 9
+    slwi    7, 3, 2
+    add     7, 25, 7
+    stw     8, 0(7)
+    addi    3, 3, 1
+    cmpwi   3, 16
+    blt     .Lldw
+
+    li      3, 16
+.Lexp:
+    addi    7, 3, -2
+    slwi    7, 7, 2
+    add     7, 25, 7
+    lwz     8, 0(7)
+    rlwinm  9, 8, 15, 0, 31
+    rlwinm  10, 8, 13, 0, 31
+    xor     9, 9, 10
+    srwi    10, 8, 10
+    xor     9, 9, 10
+    addi    7, 3, -7
+    slwi    7, 7, 2
+    add     7, 25, 7
+    lwz     10, 0(7)
+    add     9, 9, 10
+    addi    7, 3, -15
+    slwi    7, 7, 2
+    add     7, 25, 7
+    lwz     8, 0(7)
+    rlwinm  10, 8, 25, 0, 31
+    rlwinm  11, 8, 14, 0, 31
+    xor     10, 10, 11
+    srwi    11, 8, 3
+    xor     10, 10, 11
+    add     9, 9, 10
+    addi    7, 3, -16
+    slwi    7, 7, 2
+    add     7, 25, 7
+    lwz     10, 0(7)
+    add     9, 9, 10
+    slwi    7, 3, 2
+    add     7, 25, 7
+    stw     9, 0(7)
+    addi    3, 3, 1
+    cmpwi   3, 64
+    blt     .Lexp
+
+    lwz     14, 0(22)
+    lwz     15, 4(22)
+    lwz     16, 8(22)
+    lwz     17, 12(22)
+    lwz     18, 16(22)
+    lwz     19, 20(22)
+    lwz     20, 24(22)
+    lwz     21, 28(22)
+
+    bcl     20, 31, 0f
+0:  mflr    7
+    addis   24, 7, (.LK - 0b)@ha
+    addi    24, 24, (.LK - 0b)@l
+    li      23, 0
+
+.Lround:
+    slwi    7, 23, 2
+    add     7, 24, 7
+    lwz     7, 0(7)
+    slwi    8, 23, 2
+    add     8, 25, 8
+    lwz     8, 0(8)
+    rlwinm  9, 18, 26, 0, 31
+    rlwinm  10, 18, 21, 0, 31
+    xor     9, 9, 10
+    rlwinm  10, 18, 7, 0, 31
+    xor     9, 9, 10
+    add     7, 7, 8
+    add     7, 7, 21
+    add     7, 7, 9
+    and     9, 18, 19
+    andc    10, 20, 18
+    xor     9, 9, 10
+    add     7, 7, 9
+    rlwinm  9, 14, 30, 0, 31
+    rlwinm  10, 14, 19, 0, 31
+    xor     9, 9, 10
+    rlwinm  10, 14, 10, 0, 31
+    xor     9, 9, 10
+    and     10, 14, 15
+    and     11, 14, 16
+    xor     10, 10, 11
+    and     11, 15, 16
+    xor     10, 10, 11
+    add     9, 9, 10
+
+    mr      21, 20
+    mr      20, 19
+    mr      19, 18
+    add     18, 17, 7
+    mr      17, 16
+    mr      16, 15
+    mr      15, 14
+    add     14, 7, 9
+
+    addi    23, 23, 1
+    cmpwi   23, 64
+    blt     .Lround
+
+    lwz     7, 0(22)
+    add     14, 14, 7
+    stw     14, 0(22)
+    lwz     7, 4(22)
+    add     15, 15, 7
+    stw     15, 4(22)
+    lwz     7, 8(22)
+    add     16, 16, 7
+    stw     16, 8(22)
+    lwz     7, 12(22)
+    add     17, 17, 7
+    stw     17, 12(22)
+    lwz     7, 16(22)
+    add     18, 18, 7
+    stw     18, 16(22)
+    lwz     7, 20(22)
+    add     19, 19, 7
+    stw     19, 20(22)
+    lwz     7, 24(22)
+    add     20, 20, 7
+    stw     20, 24(22)
+    lwz     7, 28(22)
+    add     21, 21, 7
+    stw     21, 28(22)
+
+    lwz     14, 8(1)
+    lwz     15, 12(1)
+    lwz     16, 16(1)
+    lwz     17, 20(1)
+    lwz     18, 24(1)
+    lwz     19, 28(1)
+    lwz     20, 32(1)
+    lwz     21, 36(1)
+    lwz     22, 40(1)
+    lwz     23, 44(1)
+    lwz     24, 48(1)
+    lwz     25, 52(1)
+    lwz     0, 324(1)
+    mtlr    0
+    addi    1, 1, 320
+    blr
+    .size   apg_sha256_transform_hw, .-apg_sha256_transform_hw
+
+    .section .rodata
+    .align  4
+.LK:
+    .long 0x428a2f98,0x71374491,0xb5c0fbcf,0xe9b5dba5
+    .long 0x3956c25b,0x59f111f1,0x923f82a4,0xab1c5ed5
+    .long 0xd807aa98,0x12835b01,0x243185be,0x550c7dc3
+    .long 0x72be5d74,0x80deb1fe,0x9bdc06a7,0xc19bf174
+    .long 0xe49b69c1,0xefbe4786,0x0fc19dc6,0x240ca1cc
+    .long 0x2de92c6f,0x4a7484aa,0x5cb0a9dc,0x76f988da
+    .long 0x983e5152,0xa831c66d,0xb00327c8,0xbf597fc7
+    .long 0xc6e00bf3,0xd5a79147,0x06ca6351,0x14292967
+    .long 0x27b70a85,0x2e1b2138,0x4d2c6dfc,0x53380d13
+    .long 0x650a7354,0x766a0abb,0x81c2c92e,0x92722c85
+    .long 0xa2bfe8a1,0xa81a664b,0xc24b8b70,0xc76c51a3
+    .long 0xd192e819,0xd6990624,0xf40e3585,0x106aa070
+    .long 0x19a4c116,0x1e376c08,0x2748774c,0x34b0bcb5
+    .long 0x391c0cb3,0x4ed8aa4a,0x5b9cca4f,0x682e6ff3
+    .long 0x748f82ee,0x78a5636f,0x84c87814,0x8cc70208
+    .long 0x90befffa,0xa4506ceb,0xbef9a3f7,0xc67178f2
+
+    .section .note.GNU-stack,"",@progbits

--- a/arch/powerpc/sha256.S
+++ b/arch/powerpc/sha256.S
@@ -1,5 +1,5 @@
-// SPDX-License-Identifier: GPL-3.0-only
-// SPDX-FileCopyrightText: 2026 Meigo™ Corporation (https://github.com/meigoc)
+/* SPDX-License-Identifier: GPL-3.0-only */
+/* SPDX-FileCopyrightText: 2026 Meigo™ Corporation (https://github.com/meigoc) */
 
     .text
 

--- a/arch/riscv32/crc32.S
+++ b/arch/riscv32/crc32.S
@@ -1,0 +1,140 @@
+// SPDX-License-Identifier: GPL-3.0-only
+// SPDX-FileCopyrightText: 2026 Meigo™ Corporation (https://github.com/meigoc)
+
+    .text
+
+    .globl  apg_crc32_hw_supported
+    .type   apg_crc32_hw_supported, @function
+apg_crc32_hw_supported:
+    li      a0, 1
+    ret
+    .size   apg_crc32_hw_supported, .-apg_crc32_hw_supported
+
+    .globl  apg_crc32_update_hw
+    .type   apg_crc32_update_hw, @function
+apg_crc32_update_hw:
+    la      a3, .Ltab
+.Lc4:
+    li      t0, 4
+    bltu    a2, t0, .Lctail
+    lbu     t1, 0(a1)
+    xor     t1, t1, a0
+    andi    t1, t1, 0xff
+    slli    t1, t1, 2
+    add     t1, t1, a3
+    lw      t1, 0(t1)
+    srli    a0, a0, 8
+    xor     a0, a0, t1
+    lbu     t1, 1(a1)
+    xor     t1, t1, a0
+    andi    t1, t1, 0xff
+    slli    t1, t1, 2
+    add     t1, t1, a3
+    lw      t1, 0(t1)
+    srli    a0, a0, 8
+    xor     a0, a0, t1
+    lbu     t1, 2(a1)
+    xor     t1, t1, a0
+    andi    t1, t1, 0xff
+    slli    t1, t1, 2
+    add     t1, t1, a3
+    lw      t1, 0(t1)
+    srli    a0, a0, 8
+    xor     a0, a0, t1
+    lbu     t1, 3(a1)
+    xor     t1, t1, a0
+    andi    t1, t1, 0xff
+    slli    t1, t1, 2
+    add     t1, t1, a3
+    lw      t1, 0(t1)
+    srli    a0, a0, 8
+    xor     a0, a0, t1
+    addi    a1, a1, 4
+    addi    a2, a2, -4
+    j       .Lc4
+.Lctail:
+    beqz    a2, .Lcdone
+    lbu     t1, 0(a1)
+    xor     t1, t1, a0
+    andi    t1, t1, 0xff
+    slli    t1, t1, 2
+    add     t1, t1, a3
+    lw      t1, 0(t1)
+    srli    a0, a0, 8
+    xor     a0, a0, t1
+    addi    a1, a1, 1
+    addi    a2, a2, -1
+    j       .Lctail
+.Lcdone:
+    ret
+    .size   apg_crc32_update_hw, .-apg_crc32_update_hw
+
+    .section .rodata
+    .align  4
+.Ltab:
+    .long 0x00000000,0x77073096,0xee0e612c,0x990951ba
+    .long 0x076dc419,0x706af48f,0xe963a535,0x9e6495a3
+    .long 0x0edb8832,0x79dcb8a4,0xe0d5e91e,0x97d2d988
+    .long 0x09b64c2b,0x7eb17cbd,0xe7b82d07,0x90bf1d91
+    .long 0x1db71064,0x6ab020f2,0xf3b97148,0x84be41de
+    .long 0x1adad47d,0x6ddde4eb,0xf4d4b551,0x83d385c7
+    .long 0x136c9856,0x646ba8c0,0xfd62f97a,0x8a65c9ec
+    .long 0x14015c4f,0x63066cd9,0xfa0f3d63,0x8d080df5
+    .long 0x3b6e20c8,0x4c69105e,0xd56041e4,0xa2677172
+    .long 0x3c03e4d1,0x4b04d447,0xd20d85fd,0xa50ab56b
+    .long 0x35b5a8fa,0x42b2986c,0xdbbbc9d6,0xacbcf940
+    .long 0x32d86ce3,0x45df5c75,0xdcd60dcf,0xabd13d59
+    .long 0x26d930ac,0x51de003a,0xc8d75180,0xbfd06116
+    .long 0x21b4f4b5,0x56b3c423,0xcfba9599,0xb8bda50f
+    .long 0x2802b89e,0x5f058808,0xc60cd9b2,0xb10be924
+    .long 0x2f6f7c87,0x58684c11,0xc1611dab,0xb6662d3d
+    .long 0x76dc4190,0x01db7106,0x98d220bc,0xefd5102a
+    .long 0x71b18589,0x06b6b51f,0x9fbfe4a5,0xe8b8d433
+    .long 0x7807c9a2,0x0f00f934,0x9609a88e,0xe10e9818
+    .long 0x7f6a0dbb,0x086d3d2d,0x91646c97,0xe6635c01
+    .long 0x6b6b51f4,0x1c6c6162,0x856530d8,0xf262004e
+    .long 0x6c0695ed,0x1b01a57b,0x8208f4c1,0xf50fc457
+    .long 0x65b0d9c6,0x12b7e950,0x8bbeb8ea,0xfcb9887c
+    .long 0x62dd1ddf,0x15da2d49,0x8cd37cf3,0xfbd44c65
+    .long 0x4db26158,0x3ab551ce,0xa3bc0074,0xd4bb30e2
+    .long 0x4adfa541,0x3dd895d7,0xa4d1c46d,0xd3d6f4fb
+    .long 0x4369e96a,0x346ed9fc,0xad678846,0xda60b8d0
+    .long 0x44042d73,0x33031de5,0xaa0a4c5f,0xdd0d7cc9
+    .long 0x5005713c,0x270241aa,0xbe0b1010,0xc90c2086
+    .long 0x5768b525,0x206f85b3,0xb966d409,0xce61e49f
+    .long 0x5edef90e,0x29d9c998,0xb0d09822,0xc7d7a8b4
+    .long 0x59b33d17,0x2eb40d81,0xb7bd5c3b,0xc0ba6cad
+    .long 0xedb88320,0x9abfb3b6,0x03b6e20c,0x74b1d29a
+    .long 0xead54739,0x9dd277af,0x04db2615,0x73dc1683
+    .long 0xe3630b12,0x94643b84,0x0d6d6a3e,0x7a6a5aa8
+    .long 0xe40ecf0b,0x9309ff9d,0x0a00ae27,0x7d079eb1
+    .long 0xf00f9344,0x8708a3d2,0x1e01f268,0x6906c2fe
+    .long 0xf762575d,0x806567cb,0x196c3671,0x6e6b06e7
+    .long 0xfed41b76,0x89d32be0,0x10da7a5a,0x67dd4acc
+    .long 0xf9b9df6f,0x8ebeeff9,0x17b7be43,0x60b08ed5
+    .long 0xd6d6a3e8,0xa1d1937e,0x38d8c2c4,0x4fdff252
+    .long 0xd1bb67f1,0xa6bc5767,0x3fb506dd,0x48b2364b
+    .long 0xd80d2bda,0xaf0a1b4c,0x36034af6,0x41047a60
+    .long 0xdf60efc3,0xa867df55,0x316e8eef,0x4669be79
+    .long 0xcb61b38c,0xbc66831a,0x256fd2a0,0x5268e236
+    .long 0xcc0c7795,0xbb0b4703,0x220216b9,0x5505262f
+    .long 0xc5ba3bbe,0xb2bd0b28,0x2bb45a92,0x5cb36a04
+    .long 0xc2d7ffa7,0xb5d0cf31,0x2cd99e8b,0x5bdeae1d
+    .long 0x9b64c2b0,0xec63f226,0x756aa39c,0x026d930a
+    .long 0x9c0906a9,0xeb0e363f,0x72076785,0x05005713
+    .long 0x95bf4a82,0xe2b87a14,0x7bb12bae,0x0cb61b38
+    .long 0x92d28e9b,0xe5d5be0d,0x7cdcefb7,0x0bdbdf21
+    .long 0x86d3d2d4,0xf1d4e242,0x68ddb3f8,0x1fda836e
+    .long 0x81be16cd,0xf6b9265b,0x6fb077e1,0x18b74777
+    .long 0x88085ae6,0xff0f6a70,0x66063bca,0x11010b5c
+    .long 0x8f659eff,0xf862ae69,0x616bffd3,0x166ccf45
+    .long 0xa00ae278,0xd70dd2ee,0x4e048354,0x3903b3c2
+    .long 0xa7672661,0xd06016f7,0x4969474d,0x3e6e77db
+    .long 0xaed16a4a,0xd9d65adc,0x40df0b66,0x37d83bf0
+    .long 0xa9bcae53,0xdebb9ec5,0x47b2cf7f,0x30b5ffe9
+    .long 0xbdbdf21c,0xcabac28a,0x53b39330,0x24b4a3a6
+    .long 0xbad03605,0xcdd70693,0x54de5729,0x23d967bf
+    .long 0xb3667a2e,0xc4614ab8,0x5d681b02,0x2a6f2b94
+    .long 0xb40bbe37,0xc30c8ea1,0x5a05df1b,0x2d02ef8d
+
+    .section .note.GNU-stack,"",@progbits

--- a/arch/riscv32/crc32.S
+++ b/arch/riscv32/crc32.S
@@ -1,5 +1,5 @@
-// SPDX-License-Identifier: GPL-3.0-only
-// SPDX-FileCopyrightText: 2026 Meigo™ Corporation (https://github.com/meigoc)
+/* SPDX-License-Identifier: GPL-3.0-only */
+/* SPDX-FileCopyrightText: 2026 Meigo™ Corporation (https://github.com/meigoc) */
 
     .text
 

--- a/arch/riscv32/md5.S
+++ b/arch/riscv32/md5.S
@@ -1,0 +1,174 @@
+// SPDX-License-Identifier: GPL-3.0-only
+// SPDX-FileCopyrightText: 2026 Meigo™ Corporation (https://github.com/meigoc)
+
+    .text
+
+    .globl  apg_md5_hw_supported
+    .type   apg_md5_hw_supported, @function
+apg_md5_hw_supported:
+    li      a0, 1
+    ret
+    .size   apg_md5_hw_supported, .-apg_md5_hw_supported
+
+    .globl  apg_md5_transform_hw
+    .type   apg_md5_transform_hw, @function
+apg_md5_transform_hw:
+    addi    sp, sp, -96
+    sw      s0, 0(sp)
+    sw      s1, 4(sp)
+    sw      s2, 8(sp)
+    sw      s3, 12(sp)
+    sw      s4, 16(sp)
+    sw      s5, 20(sp)
+    sw      s6, 24(sp)
+    sw      s7, 28(sp)
+
+    mv      s4, a0
+
+    li      s5, 0
+.Lmld:
+    slli    t0, s5, 2
+    add     t0, a1, t0
+    lbu     t1, 0(t0)
+    lbu     t2, 1(t0)
+    slli    t2, t2, 8
+    or      t1, t1, t2
+    lbu     t2, 2(t0)
+    slli    t2, t2, 16
+    or      t1, t1, t2
+    lbu     t2, 3(t0)
+    slli    t2, t2, 24
+    or      t1, t1, t2
+    slli    t0, s5, 2
+    addi    t3, sp, 32
+    add     t0, t3, t0
+    sw      t1, 0(t0)
+    addi    s5, s5, 1
+    li      t0, 16
+    bltu    s5, t0, .Lmld
+
+    lw      s0, 0(s4)
+    lw      s1, 4(s4)
+    lw      s2, 8(s4)
+    lw      s3, 12(s4)
+
+    la      s6, .LT
+    la      s7, .LS
+    li      s5, 0
+
+.Lrnd:
+    li      t0, 48
+    bgeu    s5, t0, .LfI
+    li      t0, 32
+    bgeu    s5, t0, .LfH
+    li      t0, 16
+    bgeu    s5, t0, .LfG
+    xor     t1, s2, s3
+    and     t1, t1, s1
+    xor     t1, t1, s3
+    mv      t2, s5
+    j       .Lgot
+.LfG:
+    xor     t1, s1, s2
+    and     t1, t1, s3
+    xor     t1, t1, s2
+    slli    t2, s5, 2
+    add     t2, t2, s5
+    addi    t2, t2, 1
+    andi    t2, t2, 15
+    j       .Lgot
+.LfH:
+    xor     t1, s1, s2
+    xor     t1, t1, s3
+    slli    t2, s5, 1
+    add     t2, t2, s5
+    addi    t2, t2, 5
+    andi    t2, t2, 15
+    j       .Lgot
+.LfI:
+    not     t2, s3
+    or      t2, t2, s1
+    xor     t1, t2, s2
+    slli    t2, s5, 3
+    sub     t2, t2, s5
+    andi    t2, t2, 15
+.Lgot:
+    slli    t3, t2, 2
+    addi    t4, sp, 32
+    add     t3, t4, t3
+    lw      t3, 0(t3)
+    slli    t4, s5, 2
+    add     t4, s6, t4
+    lw      t4, 0(t4)
+    add     t1, t1, s0
+    add     t1, t1, t3
+    add     t1, t1, t4
+    add     t5, s7, s5
+    lbu     t5, 0(t5)
+    li      t6, 32
+    sub     t6, t6, t5
+    sll     t3, t1, t5
+    srl     t4, t1, t6
+    or      t1, t3, t4
+    add     t1, t1, s1
+
+    mv      s0, s3
+    mv      s3, s2
+    mv      s2, s1
+    mv      s1, t1
+
+    addi    s5, s5, 1
+    li      t0, 64
+    bltu    s5, t0, .Lrnd
+
+    lw      t0, 0(s4)
+    add     t0, t0, s0
+    sw      t0, 0(s4)
+    lw      t0, 4(s4)
+    add     t0, t0, s1
+    sw      t0, 4(s4)
+    lw      t0, 8(s4)
+    add     t0, t0, s2
+    sw      t0, 8(s4)
+    lw      t0, 12(s4)
+    add     t0, t0, s3
+    sw      t0, 12(s4)
+
+    lw      s0, 0(sp)
+    lw      s1, 4(sp)
+    lw      s2, 8(sp)
+    lw      s3, 12(sp)
+    lw      s4, 16(sp)
+    lw      s5, 20(sp)
+    lw      s6, 24(sp)
+    lw      s7, 28(sp)
+    addi    sp, sp, 96
+    ret
+    .size   apg_md5_transform_hw, .-apg_md5_transform_hw
+
+    .section .rodata
+    .align  4
+.LT:
+    .long 0xd76aa478,0xe8c7b756,0x242070db,0xc1bdceee
+    .long 0xf57c0faf,0x4787c62a,0xa8304613,0xfd469501
+    .long 0x698098d8,0x8b44f7af,0xffff5bb1,0x895cd7be
+    .long 0x6b901122,0xfd987193,0xa679438e,0x49b40821
+    .long 0xf61e2562,0xc040b340,0x265e5a51,0xe9b6c7aa
+    .long 0xd62f105d,0x02441453,0xd8a1e681,0xe7d3fbc8
+    .long 0x21e1cde6,0xc33707d6,0xf4d50d87,0x455a14ed
+    .long 0xa9e3e905,0xfcefa3f8,0x676f02d9,0x8d2a4c8a
+    .long 0xfffa3942,0x8771f681,0x6d9d6122,0xfde5380c
+    .long 0xa4beea44,0x4bdecfa9,0xf6bb4b60,0xbebfbc70
+    .long 0x289b7ec6,0xeaa127fa,0xd4ef3085,0x04881d05
+    .long 0xd9d4d039,0xe6db99e5,0x1fa27cf8,0xc4ac5665
+    .long 0xf4292244,0x432aff97,0xab9423a7,0xfc93a039
+    .long 0x655b59c3,0x8f0ccc92,0xffeff47d,0x85845dd1
+    .long 0x6fa87e4f,0xfe2ce6e0,0xa3014314,0x4e0811a1
+    .long 0xf7537e82,0xbd3af235,0x2ad7d2bb,0xeb86d391
+.LS:
+    .byte  7,12,17,22, 7,12,17,22, 7,12,17,22, 7,12,17,22
+    .byte  5, 9,14,20, 5, 9,14,20, 5, 9,14,20, 5, 9,14,20
+    .byte  4,11,16,23, 4,11,16,23, 4,11,16,23, 4,11,16,23
+    .byte  6,10,15,21, 6,10,15,21, 6,10,15,21, 6,10,15,21
+
+    .section .note.GNU-stack,"",@progbits

--- a/arch/riscv32/md5.S
+++ b/arch/riscv32/md5.S
@@ -1,5 +1,5 @@
-// SPDX-License-Identifier: GPL-3.0-only
-// SPDX-FileCopyrightText: 2026 Meigo™ Corporation (https://github.com/meigoc)
+/* SPDX-License-Identifier: GPL-3.0-only */
+/* SPDX-FileCopyrightText: 2026 Meigo™ Corporation (https://github.com/meigoc) */
 
     .text
 

--- a/arch/riscv32/sha256.S
+++ b/arch/riscv32/sha256.S
@@ -1,0 +1,230 @@
+// SPDX-License-Identifier: GPL-3.0-only
+// SPDX-FileCopyrightText: 2026 Meigo™ Corporation (https://github.com/meigoc)
+
+    .text
+
+    .globl  apg_sha256_hw_supported
+    .type   apg_sha256_hw_supported, @function
+apg_sha256_hw_supported:
+    li      a0, 1
+    ret
+    .size   apg_sha256_hw_supported, .-apg_sha256_hw_supported
+
+    .globl  apg_sha256_transform_hw
+    .type   apg_sha256_transform_hw, @function
+apg_sha256_transform_hw:
+    addi    sp, sp, -304
+    sw      s0, 0(sp)
+    sw      s1, 4(sp)
+    sw      s2, 8(sp)
+    sw      s3, 12(sp)
+    sw      s4, 16(sp)
+    sw      s5, 20(sp)
+    sw      s6, 24(sp)
+    sw      s7, 28(sp)
+    sw      s8, 32(sp)
+    sw      s9, 36(sp)
+    sw      s10, 40(sp)
+    sw      s11, 44(sp)
+
+    mv      s8, a0
+    addi    s11, sp, 48
+
+    li      t0, 0
+.Lldw:
+    slli    t1, t0, 2
+    add     t1, a1, t1
+    lbu     t2, 0(t1)
+    lbu     t3, 1(t1)
+    slli    t2, t2, 8
+    or      t2, t2, t3
+    lbu     t3, 2(t1)
+    slli    t2, t2, 8
+    or      t2, t2, t3
+    lbu     t3, 3(t1)
+    slli    t2, t2, 8
+    or      t2, t2, t3
+    slli    t1, t0, 2
+    add     t1, s11, t1
+    sw      t2, 0(t1)
+    addi    t0, t0, 1
+    li      t1, 16
+    bltu    t0, t1, .Lldw
+
+    li      t0, 16
+.Lexp:
+    addi    t1, t0, -2
+    slli    t1, t1, 2
+    add     t1, s11, t1
+    lw      t2, 0(t1)
+    srli    t3, t2, 17
+    slli    t4, t2, 15
+    or      t3, t3, t4
+    srli    t4, t2, 19
+    slli    t5, t2, 13
+    or      t4, t4, t5
+    xor     t3, t3, t4
+    srli    t4, t2, 10
+    xor     t3, t3, t4
+    addi    t1, t0, -7
+    slli    t1, t1, 2
+    add     t1, s11, t1
+    lw      t4, 0(t1)
+    add     t3, t3, t4
+    addi    t1, t0, -15
+    slli    t1, t1, 2
+    add     t1, s11, t1
+    lw      t2, 0(t1)
+    srli    t4, t2, 7
+    slli    t5, t2, 25
+    or      t4, t4, t5
+    srli    t5, t2, 18
+    slli    t6, t2, 14
+    or      t5, t5, t6
+    xor     t4, t4, t5
+    srli    t5, t2, 3
+    xor     t4, t4, t5
+    add     t3, t3, t4
+    addi    t1, t0, -16
+    slli    t1, t1, 2
+    add     t1, s11, t1
+    lw      t4, 0(t1)
+    add     t3, t3, t4
+    slli    t1, t0, 2
+    add     t1, s11, t1
+    sw      t3, 0(t1)
+    addi    t0, t0, 1
+    li      t1, 64
+    bltu    t0, t1, .Lexp
+
+    lw      s0, 0(s8)
+    lw      s1, 4(s8)
+    lw      s2, 8(s8)
+    lw      s3, 12(s8)
+    lw      s4, 16(s8)
+    lw      s5, 20(s8)
+    lw      s6, 24(s8)
+    lw      s7, 28(s8)
+
+    la      s10, .LK
+    li      s9, 0
+
+.Lround:
+    slli    t0, s9, 2
+    add     t0, s10, t0
+    lw      t0, 0(t0)
+    slli    t1, s9, 2
+    add     t1, s11, t1
+    lw      t1, 0(t1)
+    srli    t2, s4, 6
+    slli    t3, s4, 26
+    or      t2, t2, t3
+    srli    t3, s4, 11
+    slli    t4, s4, 21
+    or      t3, t3, t4
+    xor     t2, t2, t3
+    srli    t3, s4, 25
+    slli    t4, s4, 7
+    or      t3, t3, t4
+    xor     t2, t2, t3
+    add     t0, t0, t1
+    add     t0, t0, s7
+    add     t0, t0, t2
+    and     t2, s4, s5
+    not     t3, s4
+    and     t3, t3, s6
+    xor     t2, t2, t3
+    add     t0, t0, t2
+    srli    t2, s0, 2
+    slli    t3, s0, 30
+    or      t2, t2, t3
+    srli    t3, s0, 13
+    slli    t4, s0, 19
+    or      t3, t3, t4
+    xor     t2, t2, t3
+    srli    t3, s0, 22
+    slli    t4, s0, 10
+    or      t3, t3, t4
+    xor     t2, t2, t3
+    and     t3, s0, s1
+    and     t4, s0, s2
+    xor     t3, t3, t4
+    and     t4, s1, s2
+    xor     t3, t3, t4
+    add     t2, t2, t3
+
+    mv      s7, s6
+    mv      s6, s5
+    mv      s5, s4
+    add     s4, s3, t0
+    mv      s3, s2
+    mv      s2, s1
+    mv      s1, s0
+    add     s0, t0, t2
+
+    addi    s9, s9, 1
+    li      t0, 64
+    bltu    s9, t0, .Lround
+
+    lw      t0, 0(s8)
+    add     t0, t0, s0
+    sw      t0, 0(s8)
+    lw      t0, 4(s8)
+    add     t0, t0, s1
+    sw      t0, 4(s8)
+    lw      t0, 8(s8)
+    add     t0, t0, s2
+    sw      t0, 8(s8)
+    lw      t0, 12(s8)
+    add     t0, t0, s3
+    sw      t0, 12(s8)
+    lw      t0, 16(s8)
+    add     t0, t0, s4
+    sw      t0, 16(s8)
+    lw      t0, 20(s8)
+    add     t0, t0, s5
+    sw      t0, 20(s8)
+    lw      t0, 24(s8)
+    add     t0, t0, s6
+    sw      t0, 24(s8)
+    lw      t0, 28(s8)
+    add     t0, t0, s7
+    sw      t0, 28(s8)
+
+    lw      s0, 0(sp)
+    lw      s1, 4(sp)
+    lw      s2, 8(sp)
+    lw      s3, 12(sp)
+    lw      s4, 16(sp)
+    lw      s5, 20(sp)
+    lw      s6, 24(sp)
+    lw      s7, 28(sp)
+    lw      s8, 32(sp)
+    lw      s9, 36(sp)
+    lw      s10, 40(sp)
+    lw      s11, 44(sp)
+    addi    sp, sp, 304
+    ret
+    .size   apg_sha256_transform_hw, .-apg_sha256_transform_hw
+
+    .section .rodata
+    .align  4
+.LK:
+    .long 0x428a2f98,0x71374491,0xb5c0fbcf,0xe9b5dba5
+    .long 0x3956c25b,0x59f111f1,0x923f82a4,0xab1c5ed5
+    .long 0xd807aa98,0x12835b01,0x243185be,0x550c7dc3
+    .long 0x72be5d74,0x80deb1fe,0x9bdc06a7,0xc19bf174
+    .long 0xe49b69c1,0xefbe4786,0x0fc19dc6,0x240ca1cc
+    .long 0x2de92c6f,0x4a7484aa,0x5cb0a9dc,0x76f988da
+    .long 0x983e5152,0xa831c66d,0xb00327c8,0xbf597fc7
+    .long 0xc6e00bf3,0xd5a79147,0x06ca6351,0x14292967
+    .long 0x27b70a85,0x2e1b2138,0x4d2c6dfc,0x53380d13
+    .long 0x650a7354,0x766a0abb,0x81c2c92e,0x92722c85
+    .long 0xa2bfe8a1,0xa81a664b,0xc24b8b70,0xc76c51a3
+    .long 0xd192e819,0xd6990624,0xf40e3585,0x106aa070
+    .long 0x19a4c116,0x1e376c08,0x2748774c,0x34b0bcb5
+    .long 0x391c0cb3,0x4ed8aa4a,0x5b9cca4f,0x682e6ff3
+    .long 0x748f82ee,0x78a5636f,0x84c87814,0x8cc70208
+    .long 0x90befffa,0xa4506ceb,0xbef9a3f7,0xc67178f2
+
+    .section .note.GNU-stack,"",@progbits

--- a/arch/riscv32/sha256.S
+++ b/arch/riscv32/sha256.S
@@ -1,5 +1,5 @@
-// SPDX-License-Identifier: GPL-3.0-only
-// SPDX-FileCopyrightText: 2026 Meigo™ Corporation (https://github.com/meigoc)
+/* SPDX-License-Identifier: GPL-3.0-only */
+/* SPDX-FileCopyrightText: 2026 Meigo™ Corporation (https://github.com/meigoc) */
 
     .text
 

--- a/arch/x86/crc32.S
+++ b/arch/x86/crc32.S
@@ -1,0 +1,146 @@
+// SPDX-License-Identifier: GPL-3.0-only
+// SPDX-FileCopyrightText: 2026 Meigo™ Corporation (https://github.com/meigoc)
+
+    .intel_syntax noprefix
+    .text
+
+    .globl apg_crc32_hw_supported
+    .type  apg_crc32_hw_supported, @function
+apg_crc32_hw_supported:
+    mov     eax, 1
+    ret
+    .size apg_crc32_hw_supported, .-apg_crc32_hw_supported
+
+    .globl apg_crc32_update_hw
+    .type  apg_crc32_update_hw, @function
+apg_crc32_update_hw:
+    push    ebx
+    push    esi
+    push    edi
+    call    __x86.get_pc_thunk.bx
+    add     ebx, offset _GLOBAL_OFFSET_TABLE_
+    mov     eax, [esp+16]
+    mov     esi, [esp+20]
+    mov     ecx, [esp+24]
+    lea     edi, [ebx + .Ltab@GOTOFF]
+.Lc4:
+    cmp     ecx, 4
+    jb      .Ltail
+    movzx   edx, byte ptr [esi+0]
+    xor     dl, al
+    shr     eax, 8
+    mov     edx, [edi + edx*4]
+    xor     eax, edx
+    movzx   edx, byte ptr [esi+1]
+    xor     dl, al
+    shr     eax, 8
+    mov     edx, [edi + edx*4]
+    xor     eax, edx
+    movzx   edx, byte ptr [esi+2]
+    xor     dl, al
+    shr     eax, 8
+    mov     edx, [edi + edx*4]
+    xor     eax, edx
+    movzx   edx, byte ptr [esi+3]
+    xor     dl, al
+    shr     eax, 8
+    mov     edx, [edi + edx*4]
+    xor     eax, edx
+    add     esi, 4
+    sub     ecx, 4
+    jmp     .Lc4
+.Ltail:
+    test    ecx, ecx
+    jz      .Ldone
+    movzx   edx, byte ptr [esi]
+    xor     dl, al
+    shr     eax, 8
+    mov     edx, [edi + edx*4]
+    xor     eax, edx
+    inc     esi
+    dec     ecx
+    jmp     .Ltail
+.Ldone:
+    pop     edi
+    pop     esi
+    pop     ebx
+    ret
+    .size apg_crc32_update_hw, .-apg_crc32_update_hw
+
+    .section .text.__x86.get_pc_thunk.bx,"axG",@progbits,__x86.get_pc_thunk.bx,comdat
+    .globl  __x86.get_pc_thunk.bx
+    .hidden __x86.get_pc_thunk.bx
+    .type   __x86.get_pc_thunk.bx, @function
+__x86.get_pc_thunk.bx:
+    mov     ebx, [esp]
+    ret
+
+    .section .rodata
+    .align 4
+.Ltab:
+    .long 0x00000000,0x77073096,0xee0e612c,0x990951ba
+    .long 0x076dc419,0x706af48f,0xe963a535,0x9e6495a3
+    .long 0x0edb8832,0x79dcb8a4,0xe0d5e91e,0x97d2d988
+    .long 0x09b64c2b,0x7eb17cbd,0xe7b82d07,0x90bf1d91
+    .long 0x1db71064,0x6ab020f2,0xf3b97148,0x84be41de
+    .long 0x1adad47d,0x6ddde4eb,0xf4d4b551,0x83d385c7
+    .long 0x136c9856,0x646ba8c0,0xfd62f97a,0x8a65c9ec
+    .long 0x14015c4f,0x63066cd9,0xfa0f3d63,0x8d080df5
+    .long 0x3b6e20c8,0x4c69105e,0xd56041e4,0xa2677172
+    .long 0x3c03e4d1,0x4b04d447,0xd20d85fd,0xa50ab56b
+    .long 0x35b5a8fa,0x42b2986c,0xdbbbc9d6,0xacbcf940
+    .long 0x32d86ce3,0x45df5c75,0xdcd60dcf,0xabd13d59
+    .long 0x26d930ac,0x51de003a,0xc8d75180,0xbfd06116
+    .long 0x21b4f4b5,0x56b3c423,0xcfba9599,0xb8bda50f
+    .long 0x2802b89e,0x5f058808,0xc60cd9b2,0xb10be924
+    .long 0x2f6f7c87,0x58684c11,0xc1611dab,0xb6662d3d
+    .long 0x76dc4190,0x01db7106,0x98d220bc,0xefd5102a
+    .long 0x71b18589,0x06b6b51f,0x9fbfe4a5,0xe8b8d433
+    .long 0x7807c9a2,0x0f00f934,0x9609a88e,0xe10e9818
+    .long 0x7f6a0dbb,0x086d3d2d,0x91646c97,0xe6635c01
+    .long 0x6b6b51f4,0x1c6c6162,0x856530d8,0xf262004e
+    .long 0x6c0695ed,0x1b01a57b,0x8208f4c1,0xf50fc457
+    .long 0x65b0d9c6,0x12b7e950,0x8bbeb8ea,0xfcb9887c
+    .long 0x62dd1ddf,0x15da2d49,0x8cd37cf3,0xfbd44c65
+    .long 0x4db26158,0x3ab551ce,0xa3bc0074,0xd4bb30e2
+    .long 0x4adfa541,0x3dd895d7,0xa4d1c46d,0xd3d6f4fb
+    .long 0x4369e96a,0x346ed9fc,0xad678846,0xda60b8d0
+    .long 0x44042d73,0x33031de5,0xaa0a4c5f,0xdd0d7cc9
+    .long 0x5005713c,0x270241aa,0xbe0b1010,0xc90c2086
+    .long 0x5768b525,0x206f85b3,0xb966d409,0xce61e49f
+    .long 0x5edef90e,0x29d9c998,0xb0d09822,0xc7d7a8b4
+    .long 0x59b33d17,0x2eb40d81,0xb7bd5c3b,0xc0ba6cad
+    .long 0xedb88320,0x9abfb3b6,0x03b6e20c,0x74b1d29a
+    .long 0xead54739,0x9dd277af,0x04db2615,0x73dc1683
+    .long 0xe3630b12,0x94643b84,0x0d6d6a3e,0x7a6a5aa8
+    .long 0xe40ecf0b,0x9309ff9d,0x0a00ae27,0x7d079eb1
+    .long 0xf00f9344,0x8708a3d2,0x1e01f268,0x6906c2fe
+    .long 0xf762575d,0x806567cb,0x196c3671,0x6e6b06e7
+    .long 0xfed41b76,0x89d32be0,0x10da7a5a,0x67dd4acc
+    .long 0xf9b9df6f,0x8ebeeff9,0x17b7be43,0x60b08ed5
+    .long 0xd6d6a3e8,0xa1d1937e,0x38d8c2c4,0x4fdff252
+    .long 0xd1bb67f1,0xa6bc5767,0x3fb506dd,0x48b2364b
+    .long 0xd80d2bda,0xaf0a1b4c,0x36034af6,0x41047a60
+    .long 0xdf60efc3,0xa867df55,0x316e8eef,0x4669be79
+    .long 0xcb61b38c,0xbc66831a,0x256fd2a0,0x5268e236
+    .long 0xcc0c7795,0xbb0b4703,0x220216b9,0x5505262f
+    .long 0xc5ba3bbe,0xb2bd0b28,0x2bb45a92,0x5cb36a04
+    .long 0xc2d7ffa7,0xb5d0cf31,0x2cd99e8b,0x5bdeae1d
+    .long 0x9b64c2b0,0xec63f226,0x756aa39c,0x026d930a
+    .long 0x9c0906a9,0xeb0e363f,0x72076785,0x05005713
+    .long 0x95bf4a82,0xe2b87a14,0x7bb12bae,0x0cb61b38
+    .long 0x92d28e9b,0xe5d5be0d,0x7cdcefb7,0x0bdbdf21
+    .long 0x86d3d2d4,0xf1d4e242,0x68ddb3f8,0x1fda836e
+    .long 0x81be16cd,0xf6b9265b,0x6fb077e1,0x18b74777
+    .long 0x88085ae6,0xff0f6a70,0x66063bca,0x11010b5c
+    .long 0x8f659eff,0xf862ae69,0x616bffd3,0x166ccf45
+    .long 0xa00ae278,0xd70dd2ee,0x4e048354,0x3903b3c2
+    .long 0xa7672661,0xd06016f7,0x4969474d,0x3e6e77db
+    .long 0xaed16a4a,0xd9d65adc,0x40df0b66,0x37d83bf0
+    .long 0xa9bcae53,0xdebb9ec5,0x47b2cf7f,0x30b5ffe9
+    .long 0xbdbdf21c,0xcabac28a,0x53b39330,0x24b4a3a6
+    .long 0xbad03605,0xcdd70693,0x54de5729,0x23d967bf
+    .long 0xb3667a2e,0xc4614ab8,0x5d681b02,0x2a6f2b94
+    .long 0xb40bbe37,0xc30c8ea1,0x5a05df1b,0x2d02ef8d
+
+    .section .note.GNU-stack,"",@progbits

--- a/arch/x86/crc32.S
+++ b/arch/x86/crc32.S
@@ -1,5 +1,5 @@
-// SPDX-License-Identifier: GPL-3.0-only
-// SPDX-FileCopyrightText: 2026 Meigo™ Corporation (https://github.com/meigoc)
+/* SPDX-License-Identifier: GPL-3.0-only */
+/* SPDX-FileCopyrightText: 2026 Meigo™ Corporation (https://github.com/meigoc) */
 
     .intel_syntax noprefix
     .text

--- a/arch/x86/md5.S
+++ b/arch/x86/md5.S
@@ -1,0 +1,160 @@
+// SPDX-License-Identifier: GPL-3.0-only
+// SPDX-FileCopyrightText: 2026 Meigo™ Corporation (https://github.com/meigoc)
+
+    .intel_syntax noprefix
+    .text
+
+    .globl apg_md5_hw_supported
+    .type  apg_md5_hw_supported, @function
+apg_md5_hw_supported:
+    mov     eax, 1
+    ret
+    .size apg_md5_hw_supported, .-apg_md5_hw_supported
+
+    .globl apg_md5_transform_hw
+    .type  apg_md5_transform_hw, @function
+apg_md5_transform_hw:
+    push    ebx
+    push    esi
+    push    edi
+    push    ebp
+    sub     esp, 96
+    call    __x86.get_pc_thunk.bx
+    add     ebx, offset _GLOBAL_OFFSET_TABLE_
+
+    mov     eax, [esp+116]
+    mov     [esp+80], eax
+    mov     esi, [esp+120]
+
+    xor     ecx, ecx
+.Lmld:
+    mov     edx, [esi + ecx*4]
+    mov     [esp + ecx*4], edx
+    inc     ecx
+    cmp     ecx, 16
+    jb      .Lmld
+
+    mov     eax, [esp+80]
+    mov     edx, [eax+0]
+    mov     [esp+64], edx
+    mov     edx, [eax+4]
+    mov     [esp+68], edx
+    mov     edx, [eax+8]
+    mov     [esp+72], edx
+    mov     edx, [eax+12]
+    mov     [esp+76], edx
+
+    xor     ebp, ebp
+.Lrnd:
+    cmp     ebp, 48
+    jae     .LfI
+    cmp     ebp, 32
+    jae     .LfH
+    cmp     ebp, 16
+    jae     .LfG
+    mov     edx, [esp+72]
+    xor     edx, [esp+76]
+    and     edx, [esp+68]
+    xor     edx, [esp+76]
+    mov     esi, ebp
+    jmp     .Lgot
+.LfG:
+    mov     edx, [esp+68]
+    xor     edx, [esp+72]
+    and     edx, [esp+76]
+    xor     edx, [esp+72]
+    lea     esi, [ebp + ebp*4]
+    inc     esi
+    and     esi, 15
+    jmp     .Lgot
+.LfH:
+    mov     edx, [esp+68]
+    xor     edx, [esp+72]
+    xor     edx, [esp+76]
+    lea     esi, [ebp + ebp*2]
+    add     esi, 5
+    and     esi, 15
+    jmp     .Lgot
+.LfI:
+    mov     edx, [esp+76]
+    not     edx
+    or      edx, [esp+68]
+    xor     edx, [esp+72]
+    mov     esi, ebp
+    shl     esi, 3
+    sub     esi, ebp
+    and     esi, 15
+.Lgot:
+    add     edx, [esp+64]
+    add     edx, [esp + esi*4]
+    lea     eax, [ebx + .LT@GOTOFF]
+    add     edx, [eax + ebp*4]
+    lea     eax, [ebx + .LS@GOTOFF]
+    mov     cl, [eax + ebp]
+    rol     edx, cl
+    add     edx, [esp+68]
+
+    mov     eax, [esp+76]
+    mov     [esp+64], eax
+    mov     eax, [esp+72]
+    mov     [esp+76], eax
+    mov     eax, [esp+68]
+    mov     [esp+72], eax
+    mov     [esp+68], edx
+
+    inc     ebp
+    cmp     ebp, 64
+    jb      .Lrnd
+
+    mov     eax, [esp+80]
+    mov     edx, [esp+64]
+    add     [eax+0], edx
+    mov     edx, [esp+68]
+    add     [eax+4], edx
+    mov     edx, [esp+72]
+    add     [eax+8], edx
+    mov     edx, [esp+76]
+    add     [eax+12], edx
+
+    add     esp, 96
+    pop     ebp
+    pop     edi
+    pop     esi
+    pop     ebx
+    ret
+    .size apg_md5_transform_hw, .-apg_md5_transform_hw
+
+    .section .text.__x86.get_pc_thunk.bx,"axG",@progbits,__x86.get_pc_thunk.bx,comdat
+    .globl  __x86.get_pc_thunk.bx
+    .hidden __x86.get_pc_thunk.bx
+    .type   __x86.get_pc_thunk.bx, @function
+__x86.get_pc_thunk.bx:
+    mov     ebx, [esp]
+    ret
+
+    .section .rodata
+    .align 4
+.LT:
+    .long 0xd76aa478,0xe8c7b756,0x242070db,0xc1bdceee
+    .long 0xf57c0faf,0x4787c62a,0xa8304613,0xfd469501
+    .long 0x698098d8,0x8b44f7af,0xffff5bb1,0x895cd7be
+    .long 0x6b901122,0xfd987193,0xa679438e,0x49b40821
+    .long 0xf61e2562,0xc040b340,0x265e5a51,0xe9b6c7aa
+    .long 0xd62f105d,0x02441453,0xd8a1e681,0xe7d3fbc8
+    .long 0x21e1cde6,0xc33707d6,0xf4d50d87,0x455a14ed
+    .long 0xa9e3e905,0xfcefa3f8,0x676f02d9,0x8d2a4c8a
+    .long 0xfffa3942,0x8771f681,0x6d9d6122,0xfde5380c
+    .long 0xa4beea44,0x4bdecfa9,0xf6bb4b60,0xbebfbc70
+    .long 0x289b7ec6,0xeaa127fa,0xd4ef3085,0x04881d05
+    .long 0xd9d4d039,0xe6db99e5,0x1fa27cf8,0xc4ac5665
+    .long 0xf4292244,0x432aff97,0xab9423a7,0xfc93a039
+    .long 0x655b59c3,0x8f0ccc92,0xffeff47d,0x85845dd1
+    .long 0x6fa87e4f,0xfe2ce6e0,0xa3014314,0x4e0811a1
+    .long 0xf7537e82,0xbd3af235,0x2ad7d2bb,0xeb86d391
+.LS:
+    .byte  7,12,17,22, 7,12,17,22, 7,12,17,22, 7,12,17,22
+    .byte  5, 9,14,20, 5, 9,14,20, 5, 9,14,20, 5, 9,14,20
+    .byte  4,11,16,23, 4,11,16,23, 4,11,16,23, 4,11,16,23
+    .byte  6,10,15,21, 6,10,15,21, 6,10,15,21, 6,10,15,21
+
+    .section .note.GNU-stack,"",@progbits

--- a/arch/x86/md5.S
+++ b/arch/x86/md5.S
@@ -1,5 +1,5 @@
-// SPDX-License-Identifier: GPL-3.0-only
-// SPDX-FileCopyrightText: 2026 Meigo™ Corporation (https://github.com/meigoc)
+/* SPDX-License-Identifier: GPL-3.0-only */
+/* SPDX-FileCopyrightText: 2026 Meigo™ Corporation (https://github.com/meigoc) */
 
     .intel_syntax noprefix
     .text

--- a/arch/x86/sha256.S
+++ b/arch/x86/sha256.S
@@ -1,0 +1,200 @@
+// SPDX-License-Identifier: GPL-3.0-only
+// SPDX-FileCopyrightText: 2026 Meigo™ Corporation (https://github.com/meigoc)
+
+    .intel_syntax noprefix
+    .text
+
+    .globl apg_sha256_hw_supported
+    .type  apg_sha256_hw_supported, @function
+apg_sha256_hw_supported:
+    mov     eax, 1
+    ret
+    .size apg_sha256_hw_supported, .-apg_sha256_hw_supported
+
+    .globl apg_sha256_transform_hw
+    .type  apg_sha256_transform_hw, @function
+apg_sha256_transform_hw:
+    push    ebx
+    push    esi
+    push    edi
+    push    ebp
+    sub     esp, 304
+    call    __x86.get_pc_thunk.bx
+    add     ebx, offset _GLOBAL_OFFSET_TABLE_
+
+    mov     eax, [esp+324]
+    mov     [esp+288], eax
+    mov     esi, [esp+328]
+
+    xor     ecx, ecx
+.Lldw:
+    mov     edx, [esi + ecx*4]
+    bswap   edx
+    mov     [esp + ecx*4], edx
+    inc     ecx
+    cmp     ecx, 16
+    jb      .Lldw
+
+    mov     ecx, 16
+.Lexp:
+    mov     eax, [esp + ecx*4 - 8]
+    mov     edx, eax
+    ror     edx, 17
+    mov     edi, eax
+    ror     edi, 19
+    xor     edx, edi
+    shr     eax, 10
+    xor     edx, eax
+    add     edx, [esp + ecx*4 - 28]
+    mov     eax, [esp + ecx*4 - 60]
+    mov     edi, eax
+    ror     edi, 7
+    mov     esi, eax
+    ror     esi, 18
+    xor     edi, esi
+    shr     eax, 3
+    xor     edi, eax
+    add     edx, edi
+    add     edx, [esp + ecx*4 - 64]
+    mov     [esp + ecx*4], edx
+    inc     ecx
+    cmp     ecx, 64
+    jb      .Lexp
+
+    mov     eax, [esp+288]
+    mov     edx, [eax+0]
+    mov     [esp+256], edx
+    mov     edx, [eax+4]
+    mov     [esp+260], edx
+    mov     edx, [eax+8]
+    mov     [esp+264], edx
+    mov     edx, [eax+12]
+    mov     [esp+268], edx
+    mov     edx, [eax+16]
+    mov     [esp+272], edx
+    mov     edx, [eax+20]
+    mov     [esp+276], edx
+    mov     edx, [eax+24]
+    mov     [esp+280], edx
+    mov     edx, [eax+28]
+    mov     [esp+284], edx
+
+    xor     ebp, ebp
+.Lround:
+    mov     eax, [esp+272]
+    mov     edx, eax
+    ror     edx, 6
+    mov     esi, eax
+    ror     esi, 11
+    xor     edx, esi
+    mov     esi, eax
+    ror     esi, 25
+    xor     edx, esi
+    mov     esi, eax
+    and     esi, [esp+276]
+    not     eax
+    and     eax, [esp+280]
+    xor     esi, eax
+    add     edx, esi
+    add     edx, [esp+284]
+    add     edx, [esp + ebp*4]
+    lea     eax, [ebx + .LK@GOTOFF]
+    add     edx, [eax + ebp*4]
+    mov     edi, edx
+
+    mov     eax, [esp+256]
+    mov     edx, eax
+    ror     edx, 2
+    mov     esi, eax
+    ror     esi, 13
+    xor     edx, esi
+    mov     esi, eax
+    ror     esi, 22
+    xor     edx, esi
+    mov     esi, eax
+    and     esi, [esp+260]
+    mov     ecx, eax
+    and     ecx, [esp+264]
+    xor     esi, ecx
+    mov     ecx, [esp+260]
+    and     ecx, [esp+264]
+    xor     esi, ecx
+    add     edx, esi
+
+    mov     eax, [esp+280]
+    mov     [esp+284], eax
+    mov     eax, [esp+276]
+    mov     [esp+280], eax
+    mov     eax, [esp+272]
+    mov     [esp+276], eax
+    mov     eax, [esp+268]
+    add     eax, edi
+    mov     [esp+272], eax
+    mov     eax, [esp+264]
+    mov     [esp+268], eax
+    mov     eax, [esp+260]
+    mov     [esp+264], eax
+    mov     eax, [esp+256]
+    mov     [esp+260], eax
+    add     edi, edx
+    mov     [esp+256], edi
+
+    inc     ebp
+    cmp     ebp, 64
+    jb      .Lround
+
+    mov     eax, [esp+288]
+    mov     edx, [esp+256]
+    add     [eax+0], edx
+    mov     edx, [esp+260]
+    add     [eax+4], edx
+    mov     edx, [esp+264]
+    add     [eax+8], edx
+    mov     edx, [esp+268]
+    add     [eax+12], edx
+    mov     edx, [esp+272]
+    add     [eax+16], edx
+    mov     edx, [esp+276]
+    add     [eax+20], edx
+    mov     edx, [esp+280]
+    add     [eax+24], edx
+    mov     edx, [esp+284]
+    add     [eax+28], edx
+
+    add     esp, 304
+    pop     ebp
+    pop     edi
+    pop     esi
+    pop     ebx
+    ret
+    .size apg_sha256_transform_hw, .-apg_sha256_transform_hw
+
+    .section .text.__x86.get_pc_thunk.bx,"axG",@progbits,__x86.get_pc_thunk.bx,comdat
+    .globl  __x86.get_pc_thunk.bx
+    .hidden __x86.get_pc_thunk.bx
+    .type   __x86.get_pc_thunk.bx, @function
+__x86.get_pc_thunk.bx:
+    mov     ebx, [esp]
+    ret
+
+    .section .rodata
+    .align 4
+.LK:
+    .long 0x428a2f98,0x71374491,0xb5c0fbcf,0xe9b5dba5
+    .long 0x3956c25b,0x59f111f1,0x923f82a4,0xab1c5ed5
+    .long 0xd807aa98,0x12835b01,0x243185be,0x550c7dc3
+    .long 0x72be5d74,0x80deb1fe,0x9bdc06a7,0xc19bf174
+    .long 0xe49b69c1,0xefbe4786,0x0fc19dc6,0x240ca1cc
+    .long 0x2de92c6f,0x4a7484aa,0x5cb0a9dc,0x76f988da
+    .long 0x983e5152,0xa831c66d,0xb00327c8,0xbf597fc7
+    .long 0xc6e00bf3,0xd5a79147,0x06ca6351,0x14292967
+    .long 0x27b70a85,0x2e1b2138,0x4d2c6dfc,0x53380d13
+    .long 0x650a7354,0x766a0abb,0x81c2c92e,0x92722c85
+    .long 0xa2bfe8a1,0xa81a664b,0xc24b8b70,0xc76c51a3
+    .long 0xd192e819,0xd6990624,0xf40e3585,0x106aa070
+    .long 0x19a4c116,0x1e376c08,0x2748774c,0x34b0bcb5
+    .long 0x391c0cb3,0x4ed8aa4a,0x5b9cca4f,0x682e6ff3
+    .long 0x748f82ee,0x78a5636f,0x84c87814,0x8cc70208
+    .long 0x90befffa,0xa4506ceb,0xbef9a3f7,0xc67178f2
+
+    .section .note.GNU-stack,"",@progbits

--- a/arch/x86/sha256.S
+++ b/arch/x86/sha256.S
@@ -1,5 +1,5 @@
-// SPDX-License-Identifier: GPL-3.0-only
-// SPDX-FileCopyrightText: 2026 Meigo™ Corporation (https://github.com/meigoc)
+/* SPDX-License-Identifier: GPL-3.0-only */
+/* SPDX-FileCopyrightText: 2026 Meigo™ Corporation (https://github.com/meigoc) */
 
     .intel_syntax noprefix
     .text

--- a/cross-arm.txt
+++ b/cross-arm.txt
@@ -1,0 +1,21 @@
+[binaries]
+c         = 'clang'
+cpp       = 'clang++'
+ar        = 'llvm-ar'
+strip     = 'llvm-strip'
+objcopy   = 'llvm-objcopy'
+asm       = 'clang'
+pkgconfig = 'pkg-config'
+
+[host_machine]
+system     = 'linux'
+cpu_family = 'arm'
+cpu        = 'armv7'
+endian     = 'little'
+
+[properties]
+asm_args = ['-target', 'arm-linux-gnueabihf', '-march=armv7-a']
+
+[built-in options]
+c_args      = ['-march=armv7-a', '-target', 'arm-linux-gnueabihf']
+c_link_args = ['-fuse-ld=lld', '-target', 'arm-linux-gnueabihf']

--- a/cross-i386.txt
+++ b/cross-i386.txt
@@ -1,0 +1,21 @@
+[binaries]
+c         = 'clang'
+cpp       = 'clang++'
+ar        = 'llvm-ar'
+strip     = 'llvm-strip'
+objcopy   = 'llvm-objcopy'
+asm       = 'clang'
+pkgconfig = 'pkg-config'
+
+[host_machine]
+system     = 'linux'
+cpu_family = 'x86'
+cpu        = 'i686'
+endian     = 'little'
+
+[properties]
+asm_args = ['-target', 'i386-linux-gnu']
+
+[built-in options]
+c_args      = ['-target', 'i386-linux-gnu']
+c_link_args = ['-fuse-ld=lld', '-target', 'i386-linux-gnu']

--- a/cross-mips.txt
+++ b/cross-mips.txt
@@ -1,0 +1,21 @@
+[binaries]
+c         = 'clang'
+cpp       = 'clang++'
+ar        = 'llvm-ar'
+strip     = 'llvm-strip'
+objcopy   = 'llvm-objcopy'
+asm       = 'clang'
+pkgconfig = 'pkg-config'
+
+[host_machine]
+system     = 'linux'
+cpu_family = 'mips'
+cpu        = 'mipsel'
+endian     = 'little'
+
+[properties]
+asm_args = ['-target', 'mipsel-linux-gnu', '-march=mips32r2']
+
+[built-in options]
+c_args      = ['-march=mips32r2', '-target', 'mipsel-linux-gnu']
+c_link_args = ['-fuse-ld=lld', '-target', 'mipsel-linux-gnu']

--- a/cross-powerpc.txt
+++ b/cross-powerpc.txt
@@ -1,0 +1,21 @@
+[binaries]
+c         = 'clang'
+cpp       = 'clang++'
+ar        = 'llvm-ar'
+strip     = 'llvm-strip'
+objcopy   = 'llvm-objcopy'
+asm       = 'clang'
+pkgconfig = 'pkg-config'
+
+[host_machine]
+system     = 'linux'
+cpu_family = 'ppc'
+cpu        = 'ppc'
+endian     = 'big'
+
+[properties]
+asm_args = ['-target', 'powerpc-linux-gnu']
+
+[built-in options]
+c_args      = ['-target', 'powerpc-linux-gnu']
+c_link_args = ['-fuse-ld=lld', '-target', 'powerpc-linux-gnu']

--- a/cross-riscv32.txt
+++ b/cross-riscv32.txt
@@ -1,0 +1,21 @@
+[binaries]
+c         = 'clang'
+cpp       = 'clang++'
+ar        = 'llvm-ar'
+strip     = 'llvm-strip'
+objcopy   = 'llvm-objcopy'
+asm       = 'clang'
+pkgconfig = 'pkg-config'
+
+[host_machine]
+system     = 'linux'
+cpu_family = 'riscv32'
+cpu        = 'riscv32'
+endian     = 'little'
+
+[properties]
+asm_args = ['-target', 'riscv32-linux-gnu', '-march=rv32gc', '-mabi=ilp32']
+
+[built-in options]
+c_args      = ['-march=rv32gc', '-mabi=ilp32', '-target', 'riscv32-linux-gnu']
+c_link_args = ['-fuse-ld=lld', '-target', 'riscv32-linux-gnu']

--- a/meson.build
+++ b/meson.build
@@ -99,6 +99,63 @@ elif cpu == 'mips64'
     '-DAPG_MD5_HW_AVAILABLE=1',
     '-march=mips64r2',
   ]
+elif cpu == 'arm'
+  libapg_sources += files(
+    'arch/arm/sha256.S',
+    'arch/arm/crc32.S',
+    'arch/arm/md5.S',
+  )
+  hw_args = [
+    '-DAPG_SHA256_HW_AVAILABLE=1',
+    '-DAPG_CRC32_HW_AVAILABLE=1',
+    '-DAPG_MD5_HW_AVAILABLE=1',
+    '-march=armv7-a',
+  ]
+elif cpu == 'x86'
+  libapg_sources += files(
+    'arch/x86/sha256.S',
+    'arch/x86/crc32.S',
+    'arch/x86/md5.S',
+  )
+  hw_args = [
+    '-DAPG_SHA256_HW_AVAILABLE=1',
+    '-DAPG_CRC32_HW_AVAILABLE=1',
+    '-DAPG_MD5_HW_AVAILABLE=1',
+  ]
+elif cpu == 'riscv32'
+  libapg_sources += files(
+    'arch/riscv32/sha256.S',
+    'arch/riscv32/crc32.S',
+    'arch/riscv32/md5.S',
+  )
+  hw_args = [
+    '-DAPG_SHA256_HW_AVAILABLE=1',
+    '-DAPG_CRC32_HW_AVAILABLE=1',
+    '-DAPG_MD5_HW_AVAILABLE=1',
+  ]
+elif cpu == 'mips'
+  libapg_sources += files(
+    'arch/mips/sha256.S',
+    'arch/mips/crc32.S',
+    'arch/mips/md5.S',
+  )
+  hw_args = [
+    '-DAPG_SHA256_HW_AVAILABLE=1',
+    '-DAPG_CRC32_HW_AVAILABLE=1',
+    '-DAPG_MD5_HW_AVAILABLE=1',
+    '-march=mips32r2',
+  ]
+elif cpu == 'ppc'
+  libapg_sources += files(
+    'arch/powerpc/sha256.S',
+    'arch/powerpc/crc32.S',
+    'arch/powerpc/md5.S',
+  )
+  hw_args = [
+    '-DAPG_SHA256_HW_AVAILABLE=1',
+    '-DAPG_CRC32_HW_AVAILABLE=1',
+    '-DAPG_MD5_HW_AVAILABLE=1',
+  ]
 endif
 
 if hw_args.length() > 0


### PR DESCRIPTION
Adds optimized scalar assembly implementations of the checksum backend
  (CRC-32, MD5, SHA-256) for five 32-bit architectures, extending the existing
  64-bit backends (x86-64, aarch64, riscv64, mips64) to 32-bit targets:

  - `arch/arm/`     — ARM (AArch32 / ARMv7)
  - `arch/x86/`     — x86 (i386 / IA-32)
  - `arch/riscv32/` — RISC-V (RV32)
  - `arch/mips/`    — MIPS32 (MIPS32r2)
  - `arch/powerpc/` — PowerPC (32-bit)

  Each backend implements the ABI the C drivers already dispatch to
  (`apg_<algo>_hw_supported` / `apg_<algo>_transform_hw` / `apg_crc32_update_hw`)
  and is selected at build time in `meson.build` via `host_machine.cpu_family()`.
  Message words are assembled byte-wise (endian-independent) and symbol addressing
  is position-independent, so the backends link cleanly into the shared library.

  ## Type of Change

  - [x] New feature

  ## Related Issues

  - NurOS-Linux/libAPG#21
  - NurOS-Linux/libAPG#22
  - NurOS-Linux/libAPG#23
  - NurOS-Linux/libAPG#24
  - NurOS-Linux/libAPG#25

  ## Checklist

  - [x] Code compiles without errors
  - [x] Tests pass locally
  - [x] Code follows project style guidelines
  - [x] Documentation updated (if needed)
  - [x] Commit messages follow conventional commits format

  ## Testing

  For every target the library's own C checksum drivers were built against the new
  assembly and the full CRC-32, MD5 and SHA-256 were computed over test vectors
  (empty input, sub-block, exact block, multi-block, odd tails, all-byte-value
  data), with digests compared byte-for-byte against independent reference values.
  Verified under QEMU user-mode on `arm`, `i386`, `riscv32`, `mipsel`, big-endian
  `mips`, and `powerpc` (big-endian MIPS and PowerPC confirm endian independence).

  PIC-safety was checked by assembling each backend with `-fPIC` and linking a
  shared object with `-Wl,-z,text`. Native `x86_64` build and the existing test
  suite continue to pass unchanged.

  New `cross-*.txt` files and CI coverage were added: an `arch-asm` job that
  assembles and PIC-links every 32-bit backend, plus a full `armhf` cross job.

  ## Additional Notes

  Base integer instructions only (no crypto extensions), matching the existing
  mips64 backend; `-march` is raised only where encodings require it (`armv7-a`
  for `movw/movt`, `mips32r2` for `rotr`).